### PR TITLE
fix: skip fenced code blocks when extracting wikilinks

### DIFF
--- a/skills/llm-wiki/scripts/wiki_graph_extract.py
+++ b/skills/llm-wiki/scripts/wiki_graph_extract.py
@@ -49,6 +49,12 @@ except ImportError:
 
 WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+
+
+def strip_code(text: str) -> str:
+    return FENCED_CODE_BLOCK_RE.sub("", text)
+
 
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "index.md", "log.md", "README.md"}
 SKIP_TOP_LEVEL_DIRS = {"indexes", "graph"}
@@ -90,7 +96,7 @@ def collect_pages(wiki_root: Path) -> list[dict]:
         except (UnicodeDecodeError, OSError):
             continue
         meta, body = parse_frontmatter(text)
-        links = [m.group(1).strip() for m in WIKILINK_RE.finditer(body)]
+        links = [m.group(1).strip() for m in WIKILINK_RE.finditer(strip_code(body))]
         pages.append({
             "path": str(md_path),
             "rel_path": str(rel).replace("\\", "/"),

--- a/skills/llm-wiki/scripts/wiki_graph_lint.py
+++ b/skills/llm-wiki/scripts/wiki_graph_lint.py
@@ -56,6 +56,12 @@ import wiki_graph_extract as _extract  # noqa: E402
 
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+
+
+def strip_code(text: str) -> str:
+    return FENCED_CODE_BLOCK_RE.sub("", text)
+
 
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "index.md", "log.md", "README.md"}
 SKIP_TOP_LEVEL_DIRS = {"indexes", "graph"}
@@ -99,7 +105,7 @@ def collect_pages(wiki_root: Path) -> list[dict]:
             "slug": md_path.stem,
             "meta": meta,
             "body": body,
-            "links": [m.group(1).strip() for m in WIKILINK_RE.finditer(body)],
+            "links": [m.group(1).strip() for m in WIKILINK_RE.finditer(strip_code(body))],
         })
     return pages
 

--- a/skills/llm-wiki/scripts/wiki_lint.py
+++ b/skills/llm-wiki/scripts/wiki_lint.py
@@ -37,10 +37,15 @@ from pathlib import Path
 WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 CAPITALIZED_PHRASE_RE = re.compile(r"\b([A-Z][a-zA-Z0-9]+(?:\s+[A-Z][a-zA-Z0-9]+){0,3})\b")
+FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
 
 
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "index.md", "log.md", "README.md"}
 SKIP_TOP_LEVEL_DIRS = {"indexes", "graph"}
+
+
+def strip_code(text: str) -> str:
+    return FENCED_CODE_BLOCK_RE.sub("", text)
 
 
 def parse_frontmatter(text: str) -> tuple[dict, str, bool]:
@@ -93,7 +98,7 @@ def collect_pages(wiki_root: Path) -> list[dict]:
             continue
         meta, body, malformed = parse_frontmatter(text)
         line_count = text.count("\n") + 1
-        links = [m.group(1).strip() for m in WIKILINK_RE.finditer(body)]
+        links = [m.group(1).strip() for m in WIKILINK_RE.finditer(strip_code(body))]
         pages.append({
             "path": str(md_path),
             "rel_path": str(rel),

--- a/skills/llm-wiki/scripts/wiki_search.py
+++ b/skills/llm-wiki/scripts/wiki_search.py
@@ -38,6 +38,11 @@ from pathlib import Path
 WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 TOKEN_RE = re.compile(r"[a-z0-9]+")
+FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+
+
+def strip_code(text: str) -> str:
+    return FENCED_CODE_BLOCK_RE.sub("", text)
 
 
 def parse_frontmatter(text: str) -> tuple[dict, str]:
@@ -78,7 +83,7 @@ def slug_from_path(path: Path, wiki_root: Path) -> str:
 
 
 def extract_wikilinks(body: str) -> list[str]:
-    return [m.group(1).strip() for m in WIKILINK_RE.finditer(body)]
+    return [m.group(1).strip() for m in WIKILINK_RE.finditer(strip_code(body))]
 
 
 def collect_pages(wiki_root: Path) -> list[dict]:

--- a/skills/llm-wiki/scripts/wiki_stats.py
+++ b/skills/llm-wiki/scripts/wiki_stats.py
@@ -20,6 +20,11 @@ from pathlib import Path
 
 WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+
+
+def strip_code(text: str) -> str:
+    return FENCED_CODE_BLOCK_RE.sub("", text)
 
 
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "log.md", "README.md"}
@@ -81,7 +86,7 @@ def main():
         total_words += word_count
         # Strip frontmatter before counting wikilinks; frontmatter uses bare slugs.
         body = FRONTMATTER_RE.sub("", text, count=1) if text.startswith("---") else text
-        links = WIKILINK_RE.findall(body)
+        links = WIKILINK_RE.findall(strip_code(body))
         total_links += len(links)
         for link in links:
             target = link.split("|")[0].strip()


### PR DESCRIPTION
`[[...]]` inside a fenced code block (e.g. Telegraf TOML `[[outputs.influxdb]]`)
gets parsed as a wikilink by every script that scans page bodies for links,
producing false broken-link/orphan/edge results.

Adds `strip_code()` (strips ``` fenced blocks before wikilink extraction) to
wiki_lint.py, wiki_search.py, wiki_stats.py, wiki_graph_extract.py, and
wiki_graph_lint.py. Inline single-backtick code is untouched — wikilinks
wrapped in backticks for emphasis still count as links.

Smoke-tested per CONTRIBUTING.md against a wiki with a TOML block containing
`[[outputs.influxdb]]` plus a real `[[wikilink]]` — no false positives, real
links still tracked correctly, across all five scripts.