### PR TITLE
Give each parse-cache writer its own scratch file

### DIFF
--- a/skills/llm-wiki/.coveragerc
+++ b/skills/llm-wiki/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+branch = True
+
+[report]
+include =
+    */scripts/wiki_markdown.py
+fail_under = 90
+show_missing = True

--- a/skills/llm-wiki/scripts/init_wiki.py
+++ b/skills/llm-wiki/scripts/init_wiki.py
@@ -31,6 +31,10 @@ import sys
 from pathlib import Path
 from datetime import date
 
+from wiki_markdown import configure_utf8_streams
+
+configure_utf8_streams()
+
 
 SKILL_ROOT = Path(__file__).resolve().parent.parent
 TEMPLATES = SKILL_ROOT / "assets"

--- a/skills/llm-wiki/scripts/wiki_graph_extract.py
+++ b/skills/llm-wiki/scripts/wiki_graph_extract.py
@@ -40,6 +40,12 @@ import xml.etree.ElementTree as ET
 from collections import defaultdict
 from pathlib import Path
 
+import wiki_markdown
+from wiki_markdown import configure_utf8_streams, extract_wikilinks
+
+
+configure_utf8_streams()
+
 try:
     import yaml
 except ImportError:
@@ -51,11 +57,10 @@ except ImportError:
     sys.exit(2)
 
 
-WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "index.md", "log.md", "README.md"}
-SKIP_TOP_LEVEL_DIRS = {"indexes", "graph", "raw"}
+SKIP_TOP_LEVEL_DIRS = wiki_markdown.SKIP_TOP_LEVEL_DIRS
 
 DEFAULT_FORMATS = ["jsonl", "sqlite", "graphml"]
 
@@ -94,7 +99,7 @@ def collect_pages(wiki_root: Path) -> list[dict]:
         except (UnicodeDecodeError, OSError):
             continue
         meta, body = parse_frontmatter(text)
-        links = [m.group(1).strip() for m in WIKILINK_RE.finditer(body)]
+        links = extract_wikilinks(body)
         pages.append({
             "path": str(md_path),
             "rel_path": str(rel).replace("\\", "/"),

--- a/skills/llm-wiki/scripts/wiki_graph_lint.py
+++ b/skills/llm-wiki/scripts/wiki_graph_lint.py
@@ -43,6 +43,12 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+import wiki_markdown
+from wiki_markdown import configure_utf8_streams, extract_wikilinks
+
+
+configure_utf8_streams()
+
 try:
     import yaml
 except ImportError:
@@ -61,10 +67,9 @@ import wiki_graph_extract as _extract  # noqa: E402
 
 
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
-WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "index.md", "log.md", "README.md"}
-SKIP_TOP_LEVEL_DIRS = {"indexes", "graph", "raw"}
+SKIP_TOP_LEVEL_DIRS = wiki_markdown.SKIP_TOP_LEVEL_DIRS
 
 ALLOWED_CONFIDENCE = {"high", "medium", "low"}
 ALLOWED_STATUS = {"current", "historical", "proposed", "disputed", "superseded"}
@@ -105,7 +110,7 @@ def collect_pages(wiki_root: Path) -> list[dict]:
             "slug": md_path.stem,
             "meta": meta,
             "body": body,
-            "links": [m.group(1).strip() for m in WIKILINK_RE.finditer(body)],
+            "links": extract_wikilinks(body),
         })
     return pages
 

--- a/skills/llm-wiki/scripts/wiki_graph_query.py
+++ b/skills/llm-wiki/scripts/wiki_graph_query.py
@@ -33,6 +33,10 @@ import sys
 from collections import deque
 from pathlib import Path
 
+from wiki_markdown import configure_utf8_streams
+
+configure_utf8_streams()
+
 
 EVIDENCE_SNIPPET_LEN = 140
 

--- a/skills/llm-wiki/scripts/wiki_lint.py
+++ b/skills/llm-wiki/scripts/wiki_lint.py
@@ -33,14 +33,18 @@ from collections import Counter, defaultdict
 from datetime import date, datetime
 from pathlib import Path
 
+import wiki_markdown
+from wiki_markdown import configure_utf8_streams, extract_wikilinks
 
-WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+configure_utf8_streams()
+
+
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 CAPITALIZED_PHRASE_RE = re.compile(r"\b([A-Z][a-zA-Z0-9]+(?:\s+[A-Z][a-zA-Z0-9]+){0,3})\b")
 
 
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "index.md", "log.md", "README.md"}
-SKIP_TOP_LEVEL_DIRS = {"indexes", "graph", "raw"}
+SKIP_TOP_LEVEL_DIRS = wiki_markdown.SKIP_TOP_LEVEL_DIRS
 
 
 def parse_frontmatter(text: str) -> tuple[dict, str, bool]:
@@ -93,7 +97,7 @@ def collect_pages(wiki_root: Path) -> list[dict]:
             continue
         meta, body, malformed = parse_frontmatter(text)
         line_count = text.count("\n") + 1
-        links = [m.group(1).strip() for m in WIKILINK_RE.finditer(body)]
+        links = extract_wikilinks(body)
         pages.append({
             "path": str(md_path),
             "rel_path": str(rel),

--- a/skills/llm-wiki/scripts/wiki_markdown.py
+++ b/skills/llm-wiki/scripts/wiki_markdown.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Shared, dependency-free Markdown helpers for the LLM Wiki tools.
+
+This is deliberately a link extractor, not a renderer. It implements the
+CommonMark block/inline rules that determine whether ``[[...]]`` is literal
+code: fenced and indented code blocks, common container prefixes, raw HTML
+blocks, and backtick code spans scoped to one inline block.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+
+# Top-level directories under the wiki root that hold something other than
+# curated pages, and so are not part of the corpus any tool walks.
+#
+# Shared for the same reason WIKILINK_RE is: five scripts each carried their own
+# copy and they had already diverged — only wiki_search.py knew about
+# `.wiki-cache`. A page that one tool indexes and another ignores is a silent
+# inconsistency, and the failure surfaces far from the cause: an uncurated file
+# dropped into wiki/ gets embedded into the *tracked* vector index by the next
+# hybrid query, while lint and staleness never see it.
+#
+#   indexes/     navigational shards — they describe the wiki, they are not it
+#   graph/       compiled graph artifacts
+#   raw/         unprocessed sources, when a project keeps them inside the wiki
+#   Clippings/   saved web material: scratch input for ingest, not a page
+#   .wiki-cache/ derived retrieval artifacts
+SKIP_TOP_LEVEL_DIRS = frozenset({"indexes", "graph", "raw", "Clippings", ".wiki-cache"})
+
+WIKILINK_RE = re.compile(r"\[\[([^\]|\\\r\n]+)(?:\\?\|[^\]\r\n]+)?\]\]")
+FENCE_OPEN_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})([^\r\n]*)$")
+LIST_MARKER_RE = re.compile(r"^( {0,3})([-+*]|\d{1,9}[.)])(?:([ \t]+)(.*)|)$")
+ATX_HEADING_RE = re.compile(r"^ {0,3}#{1,6}(?:[ \t]+|$)")
+THEMATIC_BREAK_RE = re.compile(r"^ {0,3}(?:\*[ \t]*){3,}$|^ {0,3}(?:-[ \t]*){3,}$|^ {0,3}(?:_[ \t]*){3,}$")
+SETEXT_HEADING_RE = re.compile(r"^ {0,3}(?:=+|-+)[ \t]*$")
+BACKTICK_RUN_RE = re.compile(r"`+")
+HTML_PRE_BLOCK_RE = re.compile(r"^ {0,3}<(pre|script|style|textarea)(?:[ \t>]|$)", re.IGNORECASE)
+HTML_BLOCK_TAGS = (
+    "address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|"
+    "dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|"
+    "frameset|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|"
+    "nav|noframes|ol|optgroup|option|p|param|search|section|summary|table|tbody|td|"
+    "tfoot|th|thead|title|tr|track|ul"
+)
+HTML_BLOCK_TAG_RE = re.compile(
+    rf"^ {{0,3}}</?(?:{HTML_BLOCK_TAGS})(?:[ \t]|/?>|$)",
+    re.IGNORECASE,
+)
+HTML_ATTRIBUTE_NAME = r"[A-Za-z_:][A-Za-z0-9_.:-]*"
+HTML_ATTRIBUTE_VALUE = r'''(?:[^ \t\r\n"'=<>`]+|'[^']*'|"[^"]*")'''
+HTML_ATTRIBUTE = rf"(?:[ \t]+{HTML_ATTRIBUTE_NAME}(?:[ \t]*=[ \t]*{HTML_ATTRIBUTE_VALUE})?)"
+HTML_COMPLETE_TAG_RE = re.compile(
+    rf"^ {{0,3}}(?:"
+    rf"<[A-Za-z][A-Za-z0-9-]*{HTML_ATTRIBUTE}*[ \t]*/?>|"
+    rf"</[A-Za-z][A-Za-z0-9-]*[ \t]*>"
+    rf")[ \t]*$"
+)
+HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+
+def configure_utf8_streams() -> None:
+    """Keep Unicode wiki titles and diagnostics printable on Windows CLIs."""
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8")
+
+
+def _blank_preserving_newlines(text: str) -> str:
+    return "".join(char if char in "\r\n" else " " for char in text)
+
+
+def _is_escaped(text: str, position: int) -> bool:
+    backslashes = 0
+    position -= 1
+    while position >= 0 and text[position] == "\\":
+        backslashes += 1
+        position -= 1
+    return backslashes % 2 == 1
+
+
+def _indent_columns(text: str) -> tuple[int, int]:
+    """Return visual indentation columns and the first non-indent offset."""
+    columns = 0
+    offset = 0
+    while offset < len(text) and text[offset] in " \t":
+        if text[offset] == "\t":
+            columns += 4 - (columns % 4)
+        else:
+            columns += 1
+        offset += 1
+    return columns, offset
+
+
+def _visual_columns(text: str) -> int:
+    """Return the display columns occupied by a container prefix."""
+    columns = 0
+    for character in text:
+        columns += 4 - (columns % 4) if character == "\t" else 1
+    return columns
+
+
+def _strip_columns(text: str, wanted: int) -> tuple[str, bool]:
+    """Strip at least ``wanted`` indentation columns without splitting tabs."""
+    columns = 0
+    offset = 0
+    while offset < len(text) and text[offset] in " \t" and columns < wanted:
+        if text[offset] == "\t":
+            columns += 4 - (columns % 4)
+        else:
+            columns += 1
+        offset += 1
+    return text[offset:], columns >= wanted
+
+
+def _strip_blockquote_prefix(text: str) -> tuple[int, str]:
+    """Strip repeated blockquote markers and return (depth, content)."""
+    depth = 0
+    rest = text
+    while True:
+        match = re.match(r"^ {0,3}>[ \t]?", rest)
+        if not match:
+            return depth, rest
+        depth += 1
+        rest = rest[match.end():]
+
+
+def _list_marker_can_interrupt(marker: re.Match[str], paragraph_active: bool) -> bool:
+    """Apply CommonMark's special rules for a list interrupting a paragraph."""
+    if not paragraph_active:
+        return True
+    item_content = marker.group(4) or ""
+    if not item_content.strip():
+        return False
+    token = marker.group(2)
+    return not token[0].isdigit() or int(token[:-1]) == 1
+
+
+def _list_item(marker: re.Match[str]) -> tuple[int, str]:
+    """Return the continuation indent and content introduced by a list marker."""
+    prefix_without_padding = marker.group(1) + marker.group(2)
+    base_columns = _visual_columns(prefix_without_padding)
+    whitespace = marker.group(3)
+    item_content = marker.group(4) or ""
+    if whitespace is None:  # A marker alone is a valid empty list item.
+        return base_columns + 1, item_content
+
+    full_prefix = marker.group(1) + marker.group(2) + whitespace
+    padding_columns = _visual_columns(full_prefix) - base_columns
+    if padding_columns <= 4:
+        return _visual_columns(full_prefix), item_content
+
+    # CommonMark treats 5+ spaces after a marker as one container padding
+    # space plus indented content.
+    remaining_padding, _ = _strip_columns(whitespace, 1)
+    return base_columns + 1, remaining_padding + item_content
+
+
+def _logical_content(
+    raw: str,
+    containers: list[tuple[str, int]],
+    paragraph_key: tuple[tuple[str, int], ...] | None,
+    allow_new_containers: bool = True,
+) -> tuple[tuple[tuple[str, int], ...], str, bool]:
+    """Return the active container signature and its relative line content.
+
+    Container order is significant: ``- >`` is a list containing a quote,
+    while ``> -`` is a quote containing a list. Keeping the complete stack is
+    also what lets an unclosed fence end exactly when a nested item ends.
+    """
+    if not raw.strip():
+        return tuple(containers), "", False
+
+    content = raw
+    matched = 0
+    for kind, width in containers:
+        if kind == "quote":
+            marker = re.match(r"^ {0,3}>[ \t]?", content)
+            if not marker:
+                break
+            content = content[marker.end():]
+        else:
+            content, belongs = _strip_columns(content, width)
+            if not belongs:
+                break
+        matched += 1
+    if matched != len(containers):
+        del containers[matched:]
+
+    if not allow_new_containers:
+        return tuple(containers), content, False
+
+    starts_list = False
+    while True:
+        quote = re.match(r"^ {0,3}>[ \t]?", content)
+        if quote:
+            containers.append(("quote", 0))
+            content = content[quote.end():]
+            continue
+
+        list_marker = LIST_MARKER_RE.match(content)
+        paragraph_active = paragraph_key == tuple(containers)
+        if (list_marker
+                and not THEMATIC_BREAK_RE.match(content)
+                and _list_marker_can_interrupt(list_marker, paragraph_active)):
+            indent, content = _list_item(list_marker)
+            containers.append(("list", indent))
+            starts_list = True
+            continue
+        break
+
+    return tuple(containers), content, starts_list
+
+
+def _html_block_opener(content: str, paragraph_active: bool) -> tuple[str, bool] | None:
+    """Return (termination mode, already closed) for a CommonMark HTML block."""
+    if re.match(r"^ {0,3}<!--", content):
+        return "comment", "-->" in content
+    if re.match(r"^ {0,3}<\?", content):
+        return "processing", "?>" in content
+    if re.match(r"^ {0,3}<![A-Z]", content):
+        return "declaration", ">" in content
+    if re.match(r"^ {0,3}<!\[CDATA\[", content):
+        return "cdata", "]]>" in content
+
+    pre_match = HTML_PRE_BLOCK_RE.match(content)
+    if pre_match:
+        tag = pre_match.group(1).lower()
+        return f"tag:{tag}", bool(re.search(rf"</{tag}[ \t]*>", content, re.IGNORECASE))
+    if HTML_BLOCK_TAG_RE.match(content):
+        return "blank", False
+    if not paragraph_active and HTML_COMPLETE_TAG_RE.match(content):
+        return "blank", False
+    return None
+
+
+def _html_block_closed(mode: str, content: str) -> bool:
+    if mode == "comment":
+        return "-->" in content
+    if mode == "processing":
+        return "?>" in content
+    if mode == "declaration":
+        return ">" in content
+    if mode == "cdata":
+        return "]]>" in content
+    if mode.startswith("tag:"):
+        tag = mode.partition(":")[2]
+        return bool(re.search(rf"</{tag}[ \t]*>", content, re.IGNORECASE))
+    return False
+
+
+def strip_block_code(text: str) -> str:
+    """Mask fenced, indented, and raw HTML blocks.
+
+    Fences are container-aware for blockquotes and ordinary list items. An
+    unclosed fence ends at the end of its container (or the document at root).
+    """
+    output: list[str] = []
+    lines = text.splitlines(keepends=True)
+    containers: list[tuple[str, int]] = []
+    fence: tuple[str, int, tuple[tuple[str, int], ...]] | None = None
+    indented: tuple[tuple[str, int], ...] | None = None
+    html_block: tuple[str, tuple[tuple[str, int], ...]] | None = None
+    paragraph_key: tuple[tuple[str, int], ...] | None = None
+
+    for line in lines:
+        ending_length = len(line) - len(line.rstrip("\r\n"))
+        raw = line[:-ending_length] if ending_length else line
+        literal_block_active = fence is not None or html_block is not None
+        key, content, starts_list = _logical_content(
+            raw,
+            containers,
+            paragraph_key,
+            allow_new_containers=not literal_block_active,
+        )
+
+        if fence is not None:
+            fence_char, fence_length, fence_key = fence
+            if key != fence_key and content.strip():
+                fence = None
+                key, content, starts_list = _logical_content(raw, containers, paragraph_key)
+            else:
+                closing = re.fullmatch(
+                    rf" {{0,3}}{re.escape(fence_char)}{{{fence_length},}}[ \t]*",
+                    content,
+                )
+                output.append(_blank_preserving_newlines(line))
+                if closing:
+                    fence = None
+                continue
+
+        if indented is not None:
+            if key == indented and (not content.strip() or _indent_columns(content)[0] >= 4):
+                output.append(_blank_preserving_newlines(line))
+                continue
+            indented = None
+
+        if html_block is not None:
+            mode, html_key = html_block
+            if mode == "blank" and not content.strip():
+                html_block = None
+                output.append(line)
+                paragraph_key = None
+                continue
+            if key != html_key and content.strip():
+                html_block = None
+                key, content, starts_list = _logical_content(raw, containers, paragraph_key)
+            else:
+                output.append(_blank_preserving_newlines(line))
+                if _html_block_closed(mode, content):
+                    html_block = None
+                continue
+
+        if not content.strip():
+            output.append(line)
+            paragraph_key = None
+            continue
+
+        fence_match = FENCE_OPEN_RE.match(content)
+        if fence_match:
+            opening = fence_match.group(1)
+            info = fence_match.group(2)
+            if opening[0] != "`" or "`" not in info:
+                fence = (opening[0], len(opening), key)
+                output.append(_blank_preserving_newlines(line))
+                paragraph_key = None
+                continue
+
+        html_open = _html_block_opener(content, paragraph_key == key)
+        if html_open:
+            mode, already_closed = html_open
+            output.append(_blank_preserving_newlines(line))
+            if mode == "blank" or not already_closed:
+                html_block = (mode, key)
+            paragraph_key = None
+            continue
+
+        indent, _ = _indent_columns(content)
+        if indent >= 4 and paragraph_key != key:
+            indented = key
+            output.append(_blank_preserving_newlines(line))
+            continue
+
+        output.append(line)
+        if (starts_list or ATX_HEADING_RE.match(content)
+                or THEMATIC_BREAK_RE.match(content) or SETEXT_HEADING_RE.match(content)):
+            paragraph_key = None if (ATX_HEADING_RE.match(content)
+                                     or THEMATIC_BREAK_RE.match(content)
+                                     or SETEXT_HEADING_RE.match(content)) else key
+        else:
+            paragraph_key = key
+
+    return "".join(output)
+
+
+def _strip_inline_code_block(text: str) -> str:
+    runs = list(BACKTICK_RUN_RE.finditer(text))
+    spans: list[tuple[int, int]] = []
+    index = 0
+    while index < len(runs):
+        opener = runs[index]
+        if _is_escaped(text, opener.start()):
+            index += 1
+            continue
+        for closer_index in range(index + 1, len(runs)):
+            closer = runs[closer_index]
+            if len(closer.group(0)) == len(opener.group(0)):
+                spans.append((opener.start(), closer.end()))
+                index = closer_index + 1
+                break
+        else:
+            index += 1
+
+    if not spans:
+        return text
+    output: list[str] = []
+    cursor = 0
+    for start, end in spans:
+        output.append(text[cursor:start])
+        output.append(_blank_preserving_newlines(text[start:end]))
+        cursor = end
+    output.append(text[cursor:])
+    return "".join(output)
+
+
+def strip_inline_code(text: str) -> str:
+    """Mask code spans without matching delimiters across block boundaries."""
+    output: list[str] = []
+    block: list[str] = []
+    block_key: tuple[int, bool] | None = None
+
+    def flush() -> None:
+        if block:
+            output.append(_strip_inline_code_block("".join(block)))
+            block.clear()
+
+    for line in text.splitlines(keepends=True):
+        ending_length = len(line) - len(line.rstrip("\r\n"))
+        raw = line[:-ending_length] if ending_length else line
+        if not raw.strip():
+            flush()
+            output.append(line)
+            block_key = None
+            continue
+
+        quote_depth, content = _strip_blockquote_prefix(raw)
+        list_marker = LIST_MARKER_RE.match(content)
+        starts_list = bool(
+            list_marker
+            and not THEMATIC_BREAK_RE.match(content)
+            and _list_marker_can_interrupt(list_marker, bool(block))
+        )
+        is_setext = bool(SETEXT_HEADING_RE.match(content))
+        is_new_block = bool(
+            ATX_HEADING_RE.match(content)
+            or THEMATIC_BREAK_RE.match(content)
+            or is_setext
+            or starts_list
+        )
+        key = (quote_depth, is_new_block)
+        if block and (quote_depth != block_key[0] or is_new_block):
+            flush()
+        block.append(line)
+        block_key = key
+        if ATX_HEADING_RE.match(content) or THEMATIC_BREAK_RE.match(content) or is_setext:
+            flush()
+            block_key = None
+    flush()
+    return "".join(output)
+
+
+def extract_wikilinks(body: str) -> list[str]:
+    """Return cross-page wikilink targets outside Markdown code constructs."""
+    stripped = strip_block_code(body)
+    stripped = HTML_COMMENT_RE.sub(
+        lambda match: _blank_preserving_newlines(match.group(0)),
+        stripped,
+    )
+    stripped = strip_inline_code(stripped)
+    links: list[str] = []
+    for match in WIKILINK_RE.finditer(stripped):
+        if _is_escaped(stripped, match.start()):
+            continue
+        target = match.group(1).strip()
+        if target.startswith("#"):
+            continue
+        target = target.split("#", 1)[0].strip()
+        if target:
+            links.append(target)
+    return links

--- a/skills/llm-wiki/scripts/wiki_search.py
+++ b/skills/llm-wiki/scripts/wiki_search.py
@@ -48,8 +48,12 @@ from collections import Counter, defaultdict
 from datetime import date, datetime
 from pathlib import Path
 
+from wiki_markdown import (SKIP_TOP_LEVEL_DIRS, configure_utf8_streams,
+                           extract_wikilinks)
 
-WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+configure_utf8_streams()
+
+
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 TOKEN_RE = re.compile(r"[a-z0-9]+")
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
@@ -96,10 +100,6 @@ def tokenize(text: str) -> list[str]:
 
 def slug_from_path(path: Path, wiki_root: Path) -> str:
     return path.stem
-
-
-def extract_wikilinks(body: str) -> list[str]:
-    return [m.group(1).strip() for m in WIKILINK_RE.finditer(body)]
 
 
 def cache_page_body(sections: list[dict]) -> str:
@@ -174,7 +174,7 @@ def collect_pages(wiki_root: Path, cache_path: Path | None = None) -> list[dict]
         rel = md_path.relative_to(wiki_root)
         if rel.parts[0] in {"SCHEMA.md", "index.md", "log.md"} or rel.name.startswith("."):
             continue
-        if rel.parts[0] in {"indexes", "graph", "raw", ".wiki-cache"}:
+        if rel.parts[0] in SKIP_TOP_LEVEL_DIRS:
             continue
         rel_path = str(rel)
         try:

--- a/skills/llm-wiki/scripts/wiki_search.py
+++ b/skills/llm-wiki/scripts/wiki_search.py
@@ -49,7 +49,7 @@ from datetime import date, datetime
 from pathlib import Path
 
 from wiki_markdown import (SKIP_TOP_LEVEL_DIRS, configure_utf8_streams,
-                           extract_wikilinks)
+                           extract_wikilinks, strip_block_code)
 
 configure_utf8_streams()
 
@@ -62,9 +62,19 @@ TOKEN_RE = re.compile(r"[a-z0-9]+")
 # serving entries built by the previous parser: `--cache` and a cold run
 # disagree, and the vector index syncs against stale locators and text.
 # Schema history: 1 = the original format. 2 = POSIX cache keys and
-# newline-normalized content hashes.
-PARSE_CACHE_SCHEMA = 2
-HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
+# newline-normalized content hashes. 3 = CommonMark-aware code masking,
+# three-space ATX indent allowance, literal trailing hashes kept in heading
+# text, empty ATX headings recognized, sections carrying nothing dropped.
+PARSE_CACHE_SCHEMA = 3
+# CommonMark ATX heading: up to three leading spaces, one to six hashes, then
+# either end of line (an empty heading) or a space/tab before the content.
+HEADING_RE = re.compile(r"^ {0,3}(#{1,6})(?:[ \t]+(.*?))?[ \t]*$")
+# The optional closing sequence is only a closing sequence when whitespace
+# precedes it, or when it is the whole content. Stripping any trailing hash run
+# instead renames `## C#` to `C` and `## F##` to `F`, silently corrupting the
+# heading path, the searchable text, the JSON evidence and the embedded vector
+# for every heading that legitimately ends in a hash.
+CLOSING_HASHES_RE = re.compile(r"(?:^|[ \t]+)#+[ \t]*$")
 LOCAL_EMBED_MODEL = "BAAI/bge-small-en-v1.5"
 VECTOR_INDEX_SCHEMA = "2"
 VECTOR_INDEX_NAME = "embeddings.sqlite"
@@ -250,41 +260,64 @@ def collect_pages(wiki_root: Path, cache_path: Path | None = None) -> list[dict]
 
 
 def split_sections(title: str, body: str) -> list[dict]:
-    """Split a page body into sections at ATX headings outside code fences."""
+    """Split a page body into sections at ATX headings outside code blocks.
+
+    Heading detection runs against `strip_block_code`, the same CommonMark state
+    machine the wikilink extractor uses, rather than a local fence toggle. A
+    naive toggle gets four documented cases wrong — `~~~` "closing" a backtick
+    fence, three backticks "closing" a fence of four, a closing fence with
+    trailing text, and indented code — and each mistake invents a heading inside
+    a code block, which then becomes a BM25 unit, a section locator and an
+    embedded vector. Sections keep the original lines; only the heading test
+    looks at the masked copy.
+    """
     del title  # Kept in the API for parity with the TypeScript implementation.
     sections = []
     heading_stack: list[tuple[int, str]] = []
     current_path: list[str] = []
     current_level = 0
+    current_name = ""
     current_lines: list[str] = []
-    in_fence = False
 
     def append_section() -> None:
+        text = "\n".join(current_lines)
+        # Drop a section that neither names itself nor holds text: the empty
+        # preamble of a page that opens with a heading, and the empty ATX
+        # heading with nothing under it. Either carries no evidence, yet both
+        # are scored, embedded, and consume a --per-page slot a real passage
+        # needs. An inherited path does not count as a name — only the
+        # section's own heading does.
+        if not current_name and not text.strip():
+            return
         sections.append({
             "heading_path": current_path.copy(),
             "level": current_level,
-            "text": "\n".join(current_lines),
+            "text": text,
             "section_index": len(sections),
         })
 
-    for line in body.splitlines():
-        stripped = line.strip()
-        if stripped.startswith(("```", "~~~")):
-            in_fence = not in_fence
-            current_lines.append(line)
-            continue
-        heading = None if in_fence else HEADING_RE.match(line)
+    body_lines = body.splitlines()
+    # Code lines come back blanked, newline-for-newline, so they can never match
+    # the heading pattern.
+    masked_lines = strip_block_code(body).splitlines()
+    for index, line in enumerate(body_lines):
+        masked = masked_lines[index] if index < len(masked_lines) else ""
+        heading = HEADING_RE.match(masked)
         if not heading:
             current_lines.append(line)
             continue
 
         append_section()
         current_level = len(heading.group(1))
-        heading_text = heading.group(2).strip()
+        current_name = CLOSING_HASHES_RE.sub("", heading.group(2) or "").strip()
         while heading_stack and heading_stack[-1][0] >= current_level:
             heading_stack.pop()
-        heading_stack.append((current_level, heading_text))
-        current_path = [text for _, text in heading_stack]
+        # An empty ATX heading (`###` alone) is a real section boundary, so it
+        # takes its place on the stack and keeps nesting correct — but it
+        # contributes no name, so it is left out of the visible path rather than
+        # padding it with an empty string.
+        heading_stack.append((current_level, current_name))
+        current_path = [text for _, text in heading_stack if text]
         current_lines = []
 
     append_section()

--- a/skills/llm-wiki/scripts/wiki_search.py
+++ b/skills/llm-wiki/scripts/wiki_search.py
@@ -56,6 +56,14 @@ configure_utf8_streams()
 
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 TOKEN_RE = re.compile(r"[a-z0-9]+")
+# Bump whenever the cached representation of a page changes -- how a page is
+# keyed, how it is hashed, or the fields stored per section. The cache keys
+# entries by file hash alone, so without a bump an unchanged page keeps
+# serving entries built by the previous parser: `--cache` and a cold run
+# disagree, and the vector index syncs against stale locators and text.
+# Schema history: 1 = the original format. 2 = POSIX cache keys and
+# newline-normalized content hashes.
+PARSE_CACHE_SCHEMA = 2
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
 LOCAL_EMBED_MODEL = "BAAI/bge-small-en-v1.5"
 VECTOR_INDEX_SCHEMA = "2"
@@ -121,8 +129,8 @@ def load_parse_cache(cache_path: Path) -> dict:
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         print(f"cache: rebuilding ({exc})", file=sys.stderr)
         return {}
-    if not isinstance(payload, dict) or payload.get("schema") != 1:
-        print("cache: rebuilding (unsupported schema)", file=sys.stderr)
+    if not isinstance(payload, dict) or payload.get("schema") != PARSE_CACHE_SCHEMA:
+        print(f"cache: rebuilding (schema is not {PARSE_CACHE_SCHEMA})", file=sys.stderr)
         return {}
     files = payload.get("files")
     if not isinstance(files, dict):
@@ -159,7 +167,8 @@ def write_parse_cache(cache_path: Path, files: dict) -> None:
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     temporary = Path(str(cache_path) + ".tmp")
     temporary.write_text(
-        json.dumps({"schema": 1, "files": files}, ensure_ascii=False, sort_keys=True),
+        json.dumps({"schema": PARSE_CACHE_SCHEMA, "files": files},
+                   ensure_ascii=False, sort_keys=True),
         encoding="utf-8",
     )
     os.replace(temporary, cache_path)
@@ -176,12 +185,27 @@ def collect_pages(wiki_root: Path, cache_path: Path | None = None) -> list[dict]
             continue
         if rel.parts[0] in SKIP_TOP_LEVEL_DIRS:
             continue
-        rel_path = str(rel)
+        # POSIX form, always: rel_path is the cache key, the JSON field and half
+        # of the vector-index locator. Using the native separator makes a built
+        # embeddings.sqlite unusable on any other OS -- every section looks new
+        # and triggers a full re-embed after a fresh clone.
+        rel_path = rel.as_posix()
         try:
             raw = md_path.read_bytes()
         except OSError:
             continue
-        digest = hashlib.sha256(raw).hexdigest()
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        # Normalize line endings before hashing or parsing. Two reasons, both
+        # about identity: the cache reconstructs bodies by joining on "\n", so a
+        # CRLF file would read back differently than it was parsed; and the
+        # digest feeds the section content hash, so a CRLF checkout and an LF
+        # checkout of the same commit would disagree about every section and
+        # re-embed the whole corpus.
+        text = text.replace("\r\n", "\n").replace("\r", "\n")
+        digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
         cached = cached_files.get(rel_path)
         if cached and cached.get("sha256") == digest:
             meta = cached.get("meta", {})
@@ -189,10 +213,6 @@ def collect_pages(wiki_root: Path, cache_path: Path | None = None) -> list[dict]
             sections = cached.get("sections", [])
             body = cache_page_body(sections)
         else:
-            try:
-                text = raw.decode("utf-8")
-            except UnicodeDecodeError:
-                continue
             meta, body = parse_frontmatter(text)
             links = extract_wikilinks(body)
             title = meta.get("title") or slug_from_path(md_path, wiki_root)

--- a/skills/llm-wiki/scripts/wiki_search.py
+++ b/skills/llm-wiki/scripts/wiki_search.py
@@ -44,6 +44,7 @@ import os
 import re
 import sqlite3
 import sys
+import tempfile
 from collections import Counter, defaultdict
 from datetime import date, datetime
 from pathlib import Path
@@ -174,14 +175,40 @@ def load_parse_cache(cache_path: Path) -> dict:
 
 
 def write_parse_cache(cache_path: Path, files: dict) -> None:
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = Path(str(cache_path) + ".tmp")
-    temporary.write_text(
-        json.dumps({"schema": PARSE_CACHE_SCHEMA, "files": files},
-                   ensure_ascii=False, sort_keys=True),
-        encoding="utf-8",
-    )
-    os.replace(temporary, cache_path)
+    """Persist the parse cache, tolerating concurrent writers.
+
+    Two agents (or a search and a benchmark) routinely share one wiki. A fixed
+    `<cache>.tmp` name made them collide: one process writes the scratch file
+    while another renames it, which on Windows raises PermissionError from
+    either the write or the rename — measured at 4-8 failures per 12 concurrent
+    queries. Each writer now gets its own scratch file in the destination
+    directory, so the only remaining contention is the atomic rename.
+
+    Persisting is also best-effort by nature: the cache only saves reparsing
+    work, and the results are already computed by the time it is written. A
+    losing racer therefore warns and returns rather than failing a query that
+    otherwise succeeded.
+    """
+    payload = json.dumps({"schema": PARSE_CACHE_SCHEMA, "files": files},
+                         ensure_ascii=False, sort_keys=True)
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        handle, temporary = tempfile.mkstemp(
+            dir=cache_path.parent, prefix=cache_path.name + ".", suffix=".tmp"
+        )
+    except OSError as exc:
+        print(f"cache: not written ({exc})", file=sys.stderr)
+        return
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as stream:
+            stream.write(payload)
+        os.replace(temporary, cache_path)
+    except OSError as exc:
+        print(f"cache: not written ({exc})", file=sys.stderr)
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
 
 
 def collect_pages(wiki_root: Path, cache_path: Path | None = None) -> list[dict]:

--- a/skills/llm-wiki/scripts/wiki_stats.py
+++ b/skills/llm-wiki/scripts/wiki_stats.py
@@ -17,13 +17,17 @@ import sys
 from collections import Counter
 from pathlib import Path
 
+import wiki_markdown
+from wiki_markdown import configure_utf8_streams, extract_wikilinks
 
-WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+configure_utf8_streams()
+
+
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
 
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "log.md", "README.md"}
-SKIP_TOP_LEVEL_DIRS = {"indexes", "graph", "raw"}
+SKIP_TOP_LEVEL_DIRS = wiki_markdown.SKIP_TOP_LEVEL_DIRS
 
 
 def parse_type(text: str) -> str | None:
@@ -81,7 +85,7 @@ def main():
         total_words += word_count
         # Strip frontmatter before counting wikilinks; frontmatter uses bare slugs.
         body = FRONTMATTER_RE.sub("", text, count=1) if text.startswith("---") else text
-        links = WIKILINK_RE.findall(body)
+        links = extract_wikilinks(body)
         total_links += len(links)
         for link in links:
             target = link.split("|")[0].strip()

--- a/skills/llm-wiki/tests/test_cache_concurrency.py
+++ b/skills/llm-wiki/tests/test_cache_concurrency.py
@@ -1,0 +1,97 @@
+"""Persisting the parse cache must never fail a query that already answered.
+
+Two agents on one wiki, or a search running beside a benchmark, are ordinary.
+The cache is pure optimization: by the time it is written the results are
+computed, so a writer that loses a race has nothing to report but a warning.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import wiki_search  # noqa: E402
+
+
+def build_wiki(root: Path, pages: int = 20) -> None:
+    (root / "concepts").mkdir(parents=True)
+    for index in range(pages):
+        (root / "concepts" / f"p{index}.md").write_text(
+            f"---\ntype: concept\ntitle: P{index}\n---\n\n# P{index}\n\ngamma delta {index}\n",
+            encoding="utf-8",
+        )
+
+
+class ConcurrentCacheTests(unittest.TestCase):
+    def test_concurrent_writers_neither_fail_nor_corrupt_the_cache(self):
+        # A fixed `<cache>.tmp` name makes writers collide: one writes the
+        # scratch file while another renames it. On Windows that raises
+        # PermissionError from either operation, and the query exits non-zero
+        # with no output at all -- after retrieval had already succeeded.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+            failures: list[str] = []
+            counts: list[int] = []
+            barrier = threading.Barrier(12)
+
+            def worker() -> None:
+                barrier.wait()
+                try:
+                    counts.append(len(wiki_search.collect_pages(root, cache)))
+                except Exception as error:  # noqa: BLE001 - the point is that none escape
+                    failures.append(f"{type(error).__name__}: {error}")
+
+            threads = [threading.Thread(target=worker) for _ in range(12)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+            self.assertEqual([], failures)
+            self.assertEqual({20}, set(counts))
+            # Every scratch file is either renamed into place or cleaned up.
+            self.assertEqual([], list(cache.parent.glob("*.tmp")))
+            payload = json.loads(cache.read_text(encoding="utf-8"))
+            self.assertEqual(wiki_search.PARSE_CACHE_SCHEMA, payload["schema"])
+            self.assertEqual(20, len(payload["files"]))
+
+    def test_an_unwritable_cache_directory_does_not_fail_the_query(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root, pages=3)
+            # A file where the cache directory should be: mkdir and mkstemp both
+            # fail, and the query must still answer.
+            (root / ".wiki-cache").write_text("not a directory", encoding="utf-8")
+
+            pages = wiki_search.collect_pages(root, root / ".wiki-cache" / "search-index.json")
+
+            self.assertEqual(3, len(pages))
+
+    def test_a_failed_rename_leaves_no_scratch_file_behind(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root, pages=2)
+            cache_dir = root / ".wiki-cache"
+            cache_dir.mkdir(parents=True)
+            # A directory occupying the cache path: the write succeeds and the
+            # rename cannot.
+            (cache_dir / "search-index.json").mkdir()
+
+            pages = wiki_search.collect_pages(root, cache_dir / "search-index.json")
+
+            self.assertEqual(2, len(pages))
+            self.assertEqual([], list(cache_dir.glob("*.tmp")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/llm-wiki/tests/test_markdown.py
+++ b/skills/llm-wiki/tests/test_markdown.py
@@ -1,0 +1,317 @@
+"""Business rules for the shared Markdown layer.
+
+Two contracts are under test, and they are the reason the module exists:
+
+* a ``[[wikilink]]`` becomes a backlink and a graph edge only when a Markdown
+  reader would see it as prose, never when it is code or raw HTML;
+* every tool agrees on which files are wiki pages at all.
+
+Both used to be decided per script, and both had already drifted.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+import sys  # noqa: E402
+
+sys.path.insert(0, str(SCRIPTS))
+
+import wiki_graph_extract  # noqa: E402
+import wiki_graph_lint  # noqa: E402
+import wiki_lint  # noqa: E402
+import wiki_markdown  # noqa: E402
+import wiki_search  # noqa: E402
+import wiki_stats  # noqa: E402
+
+
+class NavigableLinkContractTests(unittest.TestCase):
+    """A link is navigable only when a Markdown reader would see it as prose."""
+
+    def test_extracts_aliases_and_escaped_table_aliases(self):
+        body = "[[plain]] [[shown|Alias]] [[table\\|Table alias]] [[#local]]"
+        self.assertEqual(
+            ["plain", "shown", "table"],
+            wiki_markdown.extract_wikilinks(body),
+        )
+
+    def test_escaped_wikilink_is_literal_but_even_backslashes_leave_it_visible(self):
+        body = r"\[[escaped]] \\[[visible]] [[ordinary]]"
+        self.assertEqual(
+            ["visible", "ordinary"],
+            wiki_markdown.extract_wikilinks(body),
+        )
+
+    def test_blank_target_and_local_anchor_do_not_create_graph_nodes(self):
+        body = "[[   ]] [[#installation]] [[guide#installation|Install]]"
+        self.assertEqual(["guide"], wiki_markdown.extract_wikilinks(body))
+
+    def test_cross_page_anchor_resolves_to_page_and_multiline_link_is_rejected(self):
+        body = "[[page#section|Section]] [[broken\nlink]] [[real]]"
+        self.assertEqual(["page", "real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_ignores_inline_code(self):
+        body = "`[[one]]` ``code ` [[two]]`` [[real]]"
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_unmatched_backtick_is_prose_not_an_open_ended_code_span(self):
+        body = "An unmatched ` delimiter leaves [[the-link]] visible."
+        self.assertEqual(["the-link"], wiki_markdown.extract_wikilinks(body))
+
+    def test_code_span_delimiters_must_have_equal_length(self):
+        body = "``code ` [[hidden]] `` [[visible]]"
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_escaped_backticks_do_not_create_code_spans(self):
+        body = r"\`[[visible]]\` [[real]]"
+        self.assertEqual(["visible", "real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_code_spans_do_not_cross_paragraph_boundaries(self):
+        body = "`open\n\n[[visible]]\n\nclose` [[also-visible]]"
+        self.assertEqual(
+            ["visible", "also-visible"],
+            wiki_markdown.extract_wikilinks(body),
+        )
+
+    def test_code_span_does_not_cross_heading_or_thematic_break_blocks(self):
+        body = "`open\n# [[heading]]\n\n`open\n---\n[[after-break]]"
+        self.assertEqual(
+            ["heading", "after-break"],
+            wiki_markdown.extract_wikilinks(body),
+        )
+
+    def test_code_span_does_not_cross_setext_heading_boundary(self):
+        body = "`heading\n===\n[[visible]]`"
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_ordered_marker_other_than_one_does_not_interrupt_paragraph(self):
+        body = "paragraph\n2.     [[visible-continuation]]"
+        self.assertEqual(
+            ["visible-continuation"],
+            wiki_markdown.extract_wikilinks(body),
+        )
+
+    def test_indentation_does_not_interrupt_a_paragraph(self):
+        body = "paragraph\n    [[continuation]]\n"
+        self.assertEqual(["continuation"], wiki_markdown.extract_wikilinks(body))
+
+
+class LiteralBlockContractTests(unittest.TestCase):
+    """Examples and raw code must never become backlinks or graph edges."""
+
+    def test_ignores_four_character_fence_containing_triple_fence(self):
+        body = "````md\n[[fake]]\n```\n````\n[[real]]\n"
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_accepts_longer_closing_fence(self):
+        body = "```md\n[[fake]]\n`````\n[[real]]\n"
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_ignores_tilde_fence(self):
+        body = "~~~~\n[[fake]]\n~~~~\n[[real]]\n"
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_wrong_fence_character_and_short_fence_do_not_close_block(self):
+        body = (
+            "````\n[[hidden-a]]\n~~~\n[[hidden-b]]\n```\n[[hidden-c]]\n"
+            "````\n[[visible]]"
+        )
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_closing_fence_with_trailing_text_is_not_a_closer(self):
+        body = "```\n[[hidden-a]]\n``` trailing\n[[hidden-b]]\n```\n[[visible]]"
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_backtick_in_backtick_fence_info_invalidates_the_opener(self):
+        body = "```language`option\n[[visible]]"
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_unclosed_fence_consumes_rest_of_document(self):
+        body = "[[before]]\n```\n[[inside]]\n"
+        self.assertEqual(["before"], wiki_markdown.extract_wikilinks(body))
+
+    def test_indented_code_and_tab_indented_code_are_ignored(self):
+        body = "    [[space-code]]\n\n\t[[tab-code]]\n\n[[real]]"
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_excess_list_padding_creates_indented_code(self):
+        body = "-     [[indented-code]]\n\n- [[visible-item]]"
+        self.assertEqual(["visible-item"], wiki_markdown.extract_wikilinks(body))
+
+    def test_tab_padded_list_continuation_keeps_code_in_the_list(self):
+        # The blank line is significant: indented code cannot interrupt the
+        # preceding paragraph, even inside a list item.
+        body = "- item\n\n\t    [[hidden]]\n\n[[visible]]"
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_fences_inside_blockquotes_and_lists_are_ignored(self):
+        body = (
+            "> ~~~~\n> [[quoted]]\n> ~~~~~\n\n"
+            "10. item\n    ```\n    [[listed]]\n    ````\n\n"
+            "[[real]]"
+        )
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_fences_in_mixed_list_and_blockquote_containers_are_ignored(self):
+        body = (
+            "- > ```\n  > [[list-quote]]\n  > ```\n\n"
+            "> - ~~~\n>   [[quote-list]]\n>   ~~~\n\n"
+            "[[real]]"
+        )
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_block_markers_inside_open_fences_are_literal_code(self):
+        bodies = (
+            "```\n- [[hidden-list]]\n> [[hidden-quote]]\n```\n[[visible]]",
+            "- ```\n  - [[hidden-list]]\n  > [[hidden-quote]]\n  ```\n[[visible]]",
+            "> ```\n> - [[hidden-list]]\n> > [[hidden-quote]]\n> ```\n[[visible]]",
+        )
+        for body in bodies:
+            with self.subTest(body=body):
+                self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_unclosed_container_fence_ends_with_its_container(self):
+        body = "> ```\n> [[quoted]]\n\n[[outside]]"
+        self.assertEqual(["outside"], wiki_markdown.extract_wikilinks(body))
+
+    def test_unclosed_fence_ends_when_nested_list_item_ends(self):
+        body = (
+            "- outer\n"
+            "  - inner\n"
+            "    ```\n"
+            "    [[hidden]]\n"
+            "  [[outer-visible]]\n"
+        )
+        self.assertEqual(["outer-visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_empty_list_item_still_owns_its_indented_fence(self):
+        body = "-\n  ```\n  [[hidden]]\n[[outside]]\n"
+        self.assertEqual(["outside"], wiki_markdown.extract_wikilinks(body))
+
+    def test_root_and_blockquote_fence_matrix(self):
+        for prefix in ("", "> ", "> > "):
+            for character in ("`", "~"):
+                for opening_length in range(3, 7):
+                    for extra_closing in range(3):
+                        with self.subTest(prefix=prefix, character=character,
+                                          opening=opening_length, extra=extra_closing):
+                            body = (
+                                f"{prefix}{character * opening_length}\n"
+                                f"{prefix}[[fake]]\n"
+                                f"{prefix}{character * (opening_length + extra_closing)}\n\n"
+                                "[[real]]"
+                            )
+                            self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_pre_and_comment_blocks_are_ignored(self):
+        body = (
+            "<pre>\n[[pre-code]]\n</pre>\n\n"
+            "<!--\n[[comment]]\n-->\n\n"
+            "[[real]]"
+        )
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_inline_html_comments_are_ignored(self):
+        body = "before <!-- [[comment]] --> [[real]]"
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_single_line_html_blocks_and_comments_hide_only_their_own_line(self):
+        body = (
+            "<pre>[[pre-hidden]]</pre>\n"
+            "<!-- [[comment-hidden]] -->\n"
+            "[[visible]]"
+        )
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_all_pre_like_html_blocks_hide_wikilinks_until_their_close(self):
+        for tag in ("pre", "script", "style", "textarea"):
+            with self.subTest(tag=tag):
+                body = f"<{tag}>\n[[hidden]]\n</{tag.upper()}>\n[[visible]]"
+                self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_block_markers_inside_pre_like_html_are_literal(self):
+        body = "<pre>\n- [[hidden-list]]\n> [[hidden-quote]]\n</pre>\n[[visible]]"
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_unclosed_html_block_ends_when_its_blockquote_container_ends(self):
+        body = "> <script>\n> [[script-hidden]]\n\n[[outside]]"
+        self.assertEqual(["outside"], wiki_markdown.extract_wikilinks(body))
+
+    def test_blank_terminated_commonmark_html_blocks_hide_wikilinks(self):
+        bodies = (
+            "<div>\n[[hidden]]\n</div>\n\n[[visible]]",
+            "<custom-element data-value='x'>\n[[hidden]]\n\n[[visible]]",
+        )
+        for body in bodies:
+            with self.subTest(body=body):
+                self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_processing_instruction_declaration_and_cdata_blocks_are_literal(self):
+        bodies = (
+            "<?target\n[[hidden]]\n?>\n[[visible]]",
+            "<!DECLARATION\n[[hidden]]\n>\n[[visible]]",
+            "<![CDATA[\n[[hidden]]\n]]>\n[[visible]]",
+        )
+        for body in bodies:
+            with self.subTest(body=body):
+                self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_crlf_input_preserves_links_outside_code(self):
+        body = "[[before]]\r\n~~~\r\n[[hidden]]\r\n~~~\r\n[[after]]\r\n"
+        self.assertEqual(
+            ["before", "after"],
+            wiki_markdown.extract_wikilinks(body),
+        )
+
+
+class SharedImplementationTests(unittest.TestCase):
+    """One parser and one corpus definition, imported rather than re-declared."""
+
+    TOOLS = (wiki_lint, wiki_search, wiki_graph_extract, wiki_graph_lint, wiki_stats)
+
+    def test_all_tools_share_the_same_extractor(self):
+        # Each script used to carry its own WIKILINK_RE, so a fix to one left
+        # the other four reporting different links for the same page.
+        for module in self.TOOLS:
+            with self.subTest(module=module.__name__):
+                self.assertIs(wiki_markdown.extract_wikilinks, module.extract_wikilinks)
+
+    def test_all_tools_share_one_exclusion_set(self):
+        # The five copies had already diverged: only wiki_search.py knew about
+        # .wiki-cache. A page one tool indexes and another ignores is a silent
+        # inconsistency, and it surfaces far from its cause.
+        for module in self.TOOLS:
+            with self.subTest(module=module.__name__):
+                self.assertIs(wiki_markdown.SKIP_TOP_LEVEL_DIRS, module.SKIP_TOP_LEVEL_DIRS)
+
+    def test_excluded_directories_are_named_not_guessed(self):
+        self.assertEqual(
+            {"indexes", "graph", "raw", "Clippings", ".wiki-cache"},
+            set(wiki_markdown.SKIP_TOP_LEVEL_DIRS))
+
+    def test_clippings_are_scratch_input_not_pages(self):
+        # Saved web material lands in wiki/Clippings/ as raw input for ingest.
+        # Left in the corpus it is indexed and embedded like a curated page.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            (root / "concepts").mkdir(parents=True)
+            (root / "concepts" / "alpha.md").write_text(
+                "---\ntype: concept\ntitle: Alpha\n---\n\n# Alpha\n\nGamma.\n",
+                encoding="utf-8")
+            (root / "Clippings").mkdir(parents=True)
+            (root / "Clippings" / "saved.md").write_text(
+                "---\ntitle: Saved page\n---\n\n# Saved\n\nGamma delta epsilon.\n",
+                encoding="utf-8")
+
+            pages = wiki_search.collect_pages(root)
+
+            self.assertEqual(1, len(pages))
+            self.assertTrue(pages[0]["rel_path"].endswith("alpha.md"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/llm-wiki/tests/test_parse_cache.py
+++ b/skills/llm-wiki/tests/test_parse_cache.py
@@ -1,0 +1,211 @@
+"""The parse cache and the vector index are shared artifacts, so their keys
+and hashes must not encode the machine that built them.
+
+Both halves are load-bearing once ``embeddings.sqlite`` is committed: a section
+is addressed by ``<rel_path>\x1f<index>`` and validated by a content hash, so a
+native path separator or a CRLF checkout makes every section of a fresh clone
+look new and triggers a full re-embed of the corpus.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import wiki_search  # noqa: E402
+
+
+PAGE = "---\ntype: concept\ntitle: Alpha\n---\n\n# Alpha\n\nGamma delta.\n\n## Beta\n\nEpsilon.\n"
+
+
+def build_wiki(root: Path, text: str = PAGE, newline: str = "\n") -> Path:
+    page = root / "concepts" / "alpha.md"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_bytes(text.replace("\n", newline).encode("utf-8"))
+    return page
+
+
+class PortableLocatorTests(unittest.TestCase):
+    """The committed vector index is keyed by locator, so it must be OS-neutral."""
+
+    def test_rel_path_is_posix_on_every_platform(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+
+            page = wiki_search.collect_pages(root)[0]
+
+            self.assertEqual("concepts/alpha.md", page["rel_path"])
+            self.assertNotIn("\\", page["rel_path"])
+
+    def test_section_locator_has_no_native_separators(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+
+            sections = wiki_search.collect_sections(wiki_search.collect_pages(root))
+
+            for section in sections:
+                with self.subTest(section=section["heading_path"]):
+                    self.assertTrue(
+                        wiki_search.section_locator(section).startswith("concepts/alpha.md"))
+                    self.assertNotIn("\\", wiki_search.section_locator(section))
+
+
+class NewlineNeutralIdentityTests(unittest.TestCase):
+    """A CRLF checkout and an LF checkout of one commit are the same corpus."""
+
+    def test_crlf_and_lf_checkouts_agree_on_every_content_hash(self):
+        with tempfile.TemporaryDirectory() as lf_dir, tempfile.TemporaryDirectory() as crlf_dir:
+            lf_root, crlf_root = Path(lf_dir) / "wiki", Path(crlf_dir) / "wiki"
+            build_wiki(lf_root, newline="\n")
+            build_wiki(crlf_root, newline="\r\n")
+
+            def hashes(root: Path) -> list[str]:
+                pages = wiki_search.collect_pages(root)
+                return [wiki_search.section_content_hash(section)
+                        for section in wiki_search.collect_sections(pages)]
+
+            self.assertEqual(hashes(lf_root), hashes(crlf_root))
+
+    def test_a_crlf_page_survives_the_cache_round_trip(self):
+        # The cache rebuilds a body by joining sections on "\n". Without
+        # normalization the reconstruction differs from the cold parse, so a
+        # warm run and a cold run disagree about the page they just indexed.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root, newline="\r\n")
+            cache = root / ".wiki-cache" / "search-index.json"
+
+            cold = wiki_search.collect_pages(root)
+            wiki_search.collect_pages(root, cache)
+            warm = wiki_search.collect_pages(root, cache)
+
+            self.assertEqual(cold[0]["body"].strip(), warm[0]["body"].strip())
+            self.assertNotIn("\r", warm[0]["body"])
+
+
+class ParseCacheRoundTripTests(unittest.TestCase):
+    @staticmethod
+    def state(pages: list[dict]) -> list[tuple]:
+        # Everything retrieval consumes must survive the round trip. `body` is a
+        # reconstruction, not a byte-exact copy, so it is compared stripped; the
+        # section text it is rebuilt from is compared verbatim. The leading
+        # newline it can gain comes from the empty preamble section the splitter
+        # emits for a page opening with a heading -- a separate defect, fixed
+        # where sections are split rather than papered over here.
+        return [
+            (p["slug"], p["rel_path"], p["meta"], p["links"],
+             [(s["heading_path"], s["level"], s["text"]) for s in p["sections"]],
+             p["body"].strip())
+            for p in pages
+        ]
+
+    def test_cached_run_matches_a_cold_run(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+
+            cold = wiki_search.collect_pages(root)
+            built = wiki_search.collect_pages(root, cache)
+            self.assertTrue(cache.exists())
+            warm = wiki_search.collect_pages(root, cache)
+
+            self.assertEqual(self.state(cold), self.state(built))
+            self.assertEqual(self.state(cold), self.state(warm))
+
+    def test_cache_keys_are_posix_so_another_os_can_reuse_them(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+            wiki_search.collect_pages(root, cache)
+
+            payload = json.loads(cache.read_text(encoding="utf-8"))
+
+            self.assertEqual(["concepts/alpha.md"], sorted(payload["files"]))
+
+    def test_cached_digest_is_of_the_normalized_text_not_the_raw_bytes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root, newline="\r\n")
+            cache = root / ".wiki-cache" / "search-index.json"
+            wiki_search.collect_pages(root, cache)
+
+            payload = json.loads(cache.read_text(encoding="utf-8"))
+
+            self.assertEqual(
+                hashlib.sha256(PAGE.encode("utf-8")).hexdigest(),
+                payload["files"]["concepts/alpha.md"]["sha256"],
+            )
+
+    def test_current_schema_cache_is_reused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+            wiki_search.collect_pages(root, cache)
+
+            payload = json.loads(cache.read_text(encoding="utf-8"))
+
+            self.assertEqual(wiki_search.PARSE_CACHE_SCHEMA, payload["schema"])
+            self.assertEqual(
+                [s["heading_path"] for s in wiki_search.collect_pages(root)[0]["sections"]],
+                [s["heading_path"] for s in wiki_search.collect_pages(root, cache)[0]["sections"]],
+            )
+
+    def test_cache_from_an_older_parser_is_discarded(self):
+        # Entries are keyed by file hash, so an unchanged page would keep
+        # serving output built by the previous parser. Only the schema version
+        # can catch that, which is why it must move with the representation.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            page = build_wiki(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+            digest = hashlib.sha256(page.read_bytes()).hexdigest()
+            cache.parent.mkdir(parents=True, exist_ok=True)
+            cache.write_text(json.dumps({
+                "schema": wiki_search.PARSE_CACHE_SCHEMA - 1,
+                "files": {"concepts/alpha.md": {
+                    "sha256": digest,
+                    "meta": {"type": "concept", "title": "Alpha"},
+                    "links": [],
+                    "sections": [{"heading_path": ["STALE"], "level": 1,
+                                  "text": "cached old parser output"}],
+                }},
+            }), encoding="utf-8")
+
+            pages = wiki_search.collect_pages(root, cache)
+
+            self.assertNotIn(
+                ["STALE"], [s["heading_path"] for s in pages[0]["sections"]])
+            self.assertNotIn("cached old parser output", pages[0]["body"])
+            self.assertEqual(
+                wiki_search.PARSE_CACHE_SCHEMA,
+                json.loads(cache.read_text(encoding="utf-8"))["schema"],
+            )
+
+    def test_edited_page_invalidates_its_cache_entry(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+            wiki_search.collect_pages(root, cache)
+
+            build_wiki(root, "---\ntype: concept\ntitle: Alpha\n---\n\n# Alpha\n\nRewritten omega.\n")
+            reparsed = wiki_search.collect_pages(root, cache)
+
+            self.assertIn("Rewritten omega.", reparsed[0]["body"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/llm-wiki/tests/test_sections.py
+++ b/skills/llm-wiki/tests/test_sections.py
@@ -1,0 +1,160 @@
+"""Sections are the retrieval unit, so their boundaries are a contract.
+
+A wrong boundary is not a cosmetic problem: each section becomes a BM25 unit,
+a section locator in the JSON evidence, and one embedded vector. A heading
+invented inside a code block, or a heading whose text is silently truncated,
+is indexed and retrieved exactly like a real one.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import wiki_markdown  # noqa: E402
+import wiki_search  # noqa: E402
+
+
+class SectionSplitTests(unittest.TestCase):
+    def headings(self, body: str) -> list[list[str]]:
+        return [section["heading_path"] for section in wiki_search.split_sections("T", body)]
+
+    # -- code blocks are not headings ------------------------------------
+
+    def test_headings_inside_code_fences_do_not_split(self):
+        body = "# A\n\n```\n# not a heading\n```\n\ntail\n"
+        sections = wiki_search.split_sections("T", body)
+
+        self.assertEqual(1, len(sections))
+        self.assertIn("# not a heading", sections[0]["text"])
+
+    def test_a_tilde_run_does_not_close_a_backtick_fence(self):
+        body = "# A\n```\ncode\n~~~\n# FAKE\n```\ntail\n"
+        self.assertEqual([["A"]], self.headings(body))
+
+    def test_a_shorter_run_does_not_close_a_longer_fence(self):
+        body = "# A\n````\ncode\n```\n# FAKE\n````\ntail\n"
+        self.assertEqual([["A"]], self.headings(body))
+
+    def test_a_closing_fence_may_not_carry_trailing_text(self):
+        body = "# A\n```\ncode\n``` tail\n# FAKE\n"
+        self.assertEqual([["A"]], self.headings(body))
+
+    def test_info_string_opens_but_does_not_close(self):
+        body = "# A\n```python\n# FAKE\n```\n\n## REAL\n\nx\n"
+        self.assertEqual([["A"], ["A", "REAL"]], self.headings(body))
+
+    def test_four_spaces_is_indented_code_not_a_heading(self):
+        body = "# A\n\ntext\n\n    ## FAKE\n\nbody\n"
+        self.assertEqual([["A"]], self.headings(body))
+
+    def test_splitter_and_link_extractor_agree_on_fences(self):
+        # Both must consult the same CommonMark state machine; a local fence
+        # toggle in either one drifts from the other, and the drift is invisible
+        # until a page indexes differently than it links.
+        body = "# A\n````\n[[fake-link]]\n```\n# FAKE\n````\n\n## REAL\n\n[[real-link]]\n"
+        self.assertEqual([["A"], ["A", "REAL"]], self.headings(body))
+        self.assertEqual(["real-link"], wiki_markdown.extract_wikilinks(body))
+
+    # -- what an ATX heading is ------------------------------------------
+
+    def test_up_to_three_spaces_still_marks_a_heading(self):
+        body = "# A\n\ntext\n\n   ## REAL\n\nbody\n"
+        self.assertEqual([["A"], ["A", "REAL"]], self.headings(body))
+
+    def test_a_hash_run_with_no_space_is_not_a_heading(self):
+        self.assertEqual([[]], self.headings("#no-space\n\nbody\n"))
+
+    def test_a_literal_trailing_hash_is_part_of_the_heading(self):
+        # CommonMark reads a hash run as a closing sequence only when whitespace
+        # precedes it. `C#` and `F#` are language names, and truncating them to
+        # `C` and `F` corrupts the heading path, the searchable text and the
+        # embedded vector for that section.
+        self.assertEqual([["C#"]], self.headings("# C#\n\nbody\n"))
+        self.assertEqual([["F##"]], self.headings("# F##\n\nbody\n"))
+        self.assertEqual([["Title###"]], self.headings("# Title###\n\nbody\n"))
+
+    def test_a_spaced_trailing_hash_run_is_a_closing_sequence(self):
+        self.assertEqual([["Title"]], self.headings("# Title ###\n\nbody\n"))
+        self.assertEqual([["Title"]], self.headings("# Title #\t\n\nbody\n"))
+
+    def test_an_escaped_hash_run_does_not_close_the_heading(self):
+        # CommonMark: `### foo \###` keeps the hashes as content. The backslash
+        # survives because sections store raw Markdown; tokenization drops it,
+        # so only the heading path shows it.
+        self.assertEqual([["foo \\###"]], self.headings("# foo \\###\n\nbody\n"))
+        self.assertEqual([["foo #\\##"]], self.headings("# foo #\\##\n\nbody\n"))
+
+    def test_an_empty_atx_heading_splits_without_naming_the_section(self):
+        # `##` alone is a valid empty heading, so it is a boundary and it holds
+        # its level for the headings below it -- but it contributes no name, and
+        # padding the path with "" would put an empty token into every child
+        # path and every searchable string.
+        sections = wiki_search.split_sections("T", "# A\n\nx\n\n##\n\ny\n\n### C\n\nz\n")
+
+        self.assertEqual([["A"], ["A"], ["A", "C"]], [s["heading_path"] for s in sections])
+        self.assertEqual([1, 2, 3], [s["level"] for s in sections])
+        self.assertIn("y", sections[1]["text"])
+
+    # -- sections that carry nothing are not sections ---------------------
+
+    def test_empty_preamble_before_the_first_heading_is_dropped(self):
+        # A page opening with a heading used to emit an empty section ahead of
+        # it. Empty sections are scored, embedded, and can take the top slot
+        # with an empty snippet while consuming a --per-page slot that a real
+        # passage needed.
+        sections = wiki_search.split_sections("T", "# Title\n\nBody text.\n")
+
+        self.assertEqual(1, len(sections))
+        self.assertEqual(["Title"], sections[0]["heading_path"])
+        self.assertEqual(0, sections[0]["section_index"])
+
+    def test_a_real_preamble_is_kept(self):
+        sections = wiki_search.split_sections("T", "Lead paragraph.\n\n# Title\n\nBody.\n")
+
+        self.assertEqual(2, len(sections))
+        self.assertEqual([], sections[0]["heading_path"])
+        self.assertIn("Lead paragraph.", sections[0]["text"])
+
+    def test_an_empty_heading_with_no_body_is_dropped(self):
+        # An inherited path is not a name: the section says nothing its parent
+        # does not already say, so it is worth neither a slot nor a vector.
+        self.assertEqual([["A"]], self.headings("# A\n\nx\n\n##\n"))
+
+    def test_section_indexes_stay_contiguous_after_dropping(self):
+        # section_index is half of the vector-index locator, so a gap would
+        # address a section that does not exist.
+        sections = wiki_search.split_sections("T", "# A\n\nx\n\n## B\n\ny\n")
+
+        self.assertEqual([0, 1], [section["section_index"] for section in sections])
+
+
+class SectionCacheRoundTripTests(unittest.TestCase):
+    """With no empty preamble, a cached body reproduces the cold parse exactly."""
+
+    def test_a_cached_body_no_longer_gains_a_leading_blank_line(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            (root / "concepts").mkdir(parents=True)
+            (root / "concepts" / "alpha.md").write_text(
+                "---\ntitle: Alpha\n---\n\n# Alpha\n\nGamma delta.\n\n## Beta\n\nEpsilon.\n",
+                encoding="utf-8")
+            cache = root / ".wiki-cache" / "search-index.json"
+
+            cold = wiki_search.collect_pages(root)
+            wiki_search.collect_pages(root, cache)
+            warm = wiki_search.collect_pages(root, cache)
+
+            self.assertEqual(cold[0]["body"].rstrip(), warm[0]["body"].rstrip())
+            self.assertFalse(warm[0]["body"].startswith("\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> Stacked on #9, #10 and #11. The commit under review is the tip; it touches
> one function.

`write_parse_cache()` wrote a fixed `<cache>.tmp` and renamed it into place.
Two processes sharing one wiki collide there: one writes the scratch file while
the other renames it. On Windows that raises `PermissionError` from either
operation — **measured at 4-8 failures per round with 12 concurrent `--cache`
queries** — and the exception escaped, so the command exited non-zero with no
output at all. Retrieval had already finished successfully by then.

Two agents on one wiki, or a search running beside a benchmark, hit this
routinely; it is not an exotic configuration.

Each writer now takes a unique scratch file from `tempfile.mkstemp()` in the
destination directory, so the only remaining contention is the atomic rename,
which is what `os.replace()` is for.

Persisting is also best-effort by nature: the cache saves reparsing work and
nothing else, and the results are already computed when it is written. A losing
racer now prints `cache: not written (...)` and returns instead of failing the
query. A scratch file left behind by a failed rename is removed rather than
accumulating.

### Tests

3 cases: 12 concurrent writers against one wiki (none raise, the cache stays
valid, no `.tmp` survives), an unwritable cache directory, and a rename that
cannot succeed.