### PR TITLE
Add --debug-ranking, so a rank can be explained

### DIFF
--- a/skills/llm-wiki/.coveragerc
+++ b/skills/llm-wiki/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+branch = True
+
+[report]
+include =
+    */scripts/wiki_markdown.py
+fail_under = 90
+show_missing = True

--- a/skills/llm-wiki/assets/ontology.yaml.template
+++ b/skills/llm-wiki/assets/ontology.yaml.template
@@ -48,6 +48,12 @@ node_types:
     explicit_only: true
   raw:
     explicit_only: true
+  # A document outside the wiki that pages cite in `sources:` — a repo-relative
+  # path, a URL, or any other identifier that is not a wiki slug. Minted by the
+  # extractor, never declared by a page, so it has no `maps_from`. Node id is
+  # `document:<the entry as written>`.
+  document:
+    external_only: true
 
 predicates:
   # --- Implicit predicates emitted by the extractor. ---
@@ -60,10 +66,15 @@ predicates:
       navigation, not as evidence of a typed relationship.
   sourced_from:
     subject_types: ["*"]
-    object_types: [source]
+    object_types: [source, document]
     requires_evidence: false
     description: |
-      Derived from each non-source page's frontmatter `sources:` list.
+      Derived from a page's frontmatter `sources:` list. An entry that names a
+      wiki slug resolves to that page, and is skipped on source pages, whose
+      provenance is the raw file rather than another page. An entry that names
+      anything else resolves to a `document:` node and is kept on every page
+      type, including source pages, where it is the load-bearing provenance
+      edge.
   summarizes_raw:
     subject_types: [source]
     object_types: ["*"]

--- a/skills/llm-wiki/assets/wiki-cache_gitignore.template
+++ b/skills/llm-wiki/assets/wiki-cache_gitignore.template
@@ -1,2 +1,13 @@
+# Regenerable retrieval artifacts.
+#
+# embeddings.sqlite IS tracked: it is expensive to build (a full-corpus embed
+# pass costs ~25 min and ~2 GB RSS) and cheap to carry (5 MB packed, and git
+# deltas an incremental re-embed down to ~0 KB). Committing it means a fresh
+# clone queries immediately instead of rebuilding. Re-sync it after every
+# ingest — see wiki/SCHEMA.md "Retrieval".
+#
+# search-index.json is NOT tracked: it is a pure parse cache, rebuilds in
+# seconds, and churns on every page edit.
 *
 !.gitignore
+!embeddings.sqlite

--- a/skills/llm-wiki/scripts/init_wiki.py
+++ b/skills/llm-wiki/scripts/init_wiki.py
@@ -42,6 +42,15 @@ TEMPLATES = SKILL_ROOT / "assets"
 
 SUBDIRS = ["sources", "entities", "concepts", "synthesis", "graph"]
 
+# Mirrors wiki_search.VECTOR_INDEX_NAME. Duplicated rather than imported so this
+# bootstrap script stays runnable before any dependency exists.
+VECTOR_INDEX_NAME = "embeddings.sqlite"
+INDEX_UNIGNORE_RULE = f"!{VECTOR_INDEX_NAME}"
+# The exact rule set older versions generated, before the vector index became a
+# tracked artifact. Only this shape is migrated automatically.
+LEGACY_WIKI_CACHE_IGNORE = ["*", "!.gitignore"]
+
+
 # Markers used by --upgrade to detect SCHEMA.md sections introduced in
 # specific plugin versions. Each entry: (heading_marker, version_label,
 # template_anchor, blurb).
@@ -92,6 +101,84 @@ def copy_template(src: Path, dst: Path, substitutions: dict | None = None) -> bo
     return True
 
 
+def migrate_wiki_cache_gitignore(path: Path) -> str:
+    """Teach an older `.wiki-cache/.gitignore` that the vector index is tracked.
+
+    Older versions generated `*` + `!.gitignore`, which was right when everything
+    under `.wiki-cache/` was disposable. Now the vector index is a tracked
+    artifact, and that rule set silently hides it: the upgrade builds the index,
+    then git refuses to add it without `-f`. `copy_template()` cannot fix this —
+    it returns untouched when the destination exists, which is the correct
+    behaviour for a file the user may have edited.
+
+    So the migration is surgical: only the known generated shape is rewritten,
+    and only by appending. Anything the user has customized is reported instead
+    of being edited under them.
+
+    Returns "absent", "current", "migrated", "custom", or "unreadable: <reason>".
+    """
+    if not path.exists():
+        return "absent"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return f"unreadable: {exc}"
+    rules = [line.strip() for line in text.splitlines()
+             if line.strip() and not line.strip().startswith("#")]
+    if INDEX_UNIGNORE_RULE in rules:
+        return "current"
+    if rules != LEGACY_WIKI_CACHE_IGNORE:
+        return "custom"
+    separator = "" if text.endswith("\n") else "\n"
+    try:
+        path.write_text(
+            f"{text}{separator}\n"
+            "# The vector index is tracked: it is expensive to build and cheap to\n"
+            "# carry, so a fresh clone queries immediately. Added by --upgrade.\n"
+            f"{INDEX_UNIGNORE_RULE}\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        return f"unreadable: {exc}"
+    return "migrated"
+
+
+def index_ignore_rule(project_root: Path, index_path: Path) -> str | None:
+    """Return the gitignore rule hiding the vector index, or None if it is trackable.
+
+    Asking git is the only honest check: the rule can live in the wiki's own
+    `.gitignore`, the repository root's, or a global excludes file, and only git
+    knows which one wins.
+
+    Two calls, deliberately. `-q` alone carries the verdict: 0 = ignored,
+    1 = not ignored, 128 = not a git repository. `-v` cannot be used for the
+    verdict, because it also reports a path that matched a *negated* pattern and
+    still exits 0 — so `!embeddings.sqlite`, the rule that makes the index
+    trackable, would be read as the rule hiding it. `-v` is only asked for the
+    rule text once `-q` has already said the index is ignored.
+    """
+    git = shutil.which("git")
+    if not git:
+        return None
+
+    def check(*flags: str) -> subprocess.CompletedProcess | None:
+        try:
+            return subprocess.run(
+                [git, "check-ignore", *flags, "--", str(index_path)],
+                cwd=project_root, capture_output=True, text=True,
+            )
+        except OSError:
+            return None
+
+    verdict = check("-q")
+    if verdict is None or verdict.returncode != 0:
+        return None
+    detail = check("-v")
+    if detail is not None and detail.stdout.strip():
+        return detail.stdout.strip().splitlines()[0]
+    return f"(an ignore rule matches {index_path})"
+
+
 def detect_schema_gaps(schema_path: Path) -> list[dict]:
     """Return the SCHEMA_SECTION_MARKERS entries missing from the user's SCHEMA.md."""
     if not schema_path.exists():
@@ -127,6 +214,46 @@ def print_schema_upgrade_guidance(schema_path: Path, gaps: list[dict]) -> None:
         "Diff your SCHEMA.md against the template and copy the missing\n"
         "sections in. Or run /wiki:upgrade and Claude will propose the edits\n"
         "interactively (one section at a time, never silent)."
+    )
+
+
+def report_ignored_index(index_path: Path, rule: str, ignore_status: str,
+                         cache_ignore: Path) -> None:
+    """Explain that the built index cannot be committed, and how to unblock it."""
+    stream = sys.stderr
+    print(file=stream)
+    print("=" * 64, file=stream)
+    print("Blocked: the vector index is git-ignored", file=stream)
+    print("=" * 64, file=stream)
+    print(
+        f"{index_path} is expensive to build and is meant to be committed with\n"
+        f"the pages it indexes, but git will not add it:\n"
+        f"  {rule}\n",
+        file=stream,
+    )
+    if ignore_status == "custom":
+        print(
+            f"{cache_ignore} has been customized, so it was left untouched.\n"
+            f"Add this line to it by hand:\n"
+            f"  {INDEX_UNIGNORE_RULE}",
+            file=stream,
+        )
+    elif ignore_status.startswith("unreadable"):
+        print(f"{cache_ignore} could not be updated ({ignore_status}).", file=stream)
+    else:
+        print(
+            "The rule is not in the wiki's own .wiki-cache/.gitignore — check the\n"
+            "repository root .gitignore and your global excludes file. The line\n"
+            "shown above names the file and rule responsible.\n"
+            "If that rule excludes a whole directory, the '!embeddings.sqlite'\n"
+            "negation cannot rescue it: git never descends into an excluded\n"
+            "directory, so the parent rule has to be narrowed instead.",
+            file=stream,
+        )
+    print(
+        "\nSetup is not complete. Fix the rule and rerun; nothing else here\n"
+        "is affected, and no work is lost.",
+        file=stream,
     )
 
 
@@ -213,6 +340,11 @@ def init_wiki(project_root: Path, wiki_dir: str, raw_dir: str, upgrade: bool = F
         else:
             skipped.append(str(dst.relative_to(project_root)))
 
+    cache_ignore = wiki / ".wiki-cache" / ".gitignore"
+    ignore_status = migrate_wiki_cache_gitignore(cache_ignore)
+    if ignore_status == "migrated":
+        created.append(f"{cache_ignore.relative_to(project_root)} (migrated: {INDEX_UNIGNORE_RULE})")
+
     # Report
     if created:
         print("Created:")
@@ -222,6 +354,15 @@ def init_wiki(project_root: Path, wiki_dir: str, raw_dir: str, upgrade: bool = F
         print("Already existed (skipped):")
         for path in skipped:
             print(f"  = {path}")
+
+    # Before the runtime install, not after: building the index first and only
+    # then reporting that it cannot be committed would waste a ~25-minute embed
+    # pass to deliver the news.
+    index_path = wiki / ".wiki-cache" / VECTOR_INDEX_NAME
+    blocking_rule = index_ignore_rule(project_root, index_path)
+    if blocking_rule:
+        report_ignored_index(index_path, blocking_rule, ignore_status, cache_ignore)
+        raise SystemExit(1)
 
     install_runtime(wiki)
 

--- a/skills/llm-wiki/scripts/init_wiki.py
+++ b/skills/llm-wiki/scripts/init_wiki.py
@@ -31,6 +31,10 @@ import sys
 from pathlib import Path
 from datetime import date
 
+from wiki_markdown import configure_utf8_streams
+
+configure_utf8_streams()
+
 
 SKILL_ROOT = Path(__file__).resolve().parent.parent
 TEMPLATES = SKILL_ROOT / "assets"

--- a/skills/llm-wiki/scripts/setup_wiki.py
+++ b/skills/llm-wiki/scripts/setup_wiki.py
@@ -20,9 +20,42 @@ import yaml
 import wiki_search
 
 
+def verify_parse_cache(cache_path: Path, pages: list[dict]) -> None:
+    """Setup promises a usable parse cache; a search only prefers one.
+
+    `collect_pages()` writes the cache best-effort — a query that already has
+    its answer should not fail because a concurrent writer won the rename. Setup
+    is the opposite contract: `references/retrieval-setup.md` makes
+    `search-index.json` a precondition of readiness, so an unwritable path,
+    a cache from an older parser, or a partial write must stop `"status":
+    "ready"` instead of being reported as a healthy wiki.
+    """
+    if not cache_path.exists():
+        raise RuntimeError(f"parse cache was not written: {cache_path}")
+    # Re-reading through the loader is the point: it enforces the current
+    # PARSE_CACHE_SCHEMA and the per-entry shape, so setup verifies the file a
+    # later search would actually accept, not merely that some file exists.
+    # `None` means unusable; an empty map means a usable cache for a wiki with
+    # nothing ingested yet, which is exactly the state `/wiki:init` leaves
+    # behind — treating that as corruption would fail every new wiki's setup.
+    cached = wiki_search.load_parse_cache(cache_path)
+    if cached is None:
+        raise RuntimeError(
+            f"parse cache is unusable (wrong schema or malformed): {cache_path}"
+        )
+    missing = sorted({page["rel_path"] for page in pages} - cached.keys())
+    if missing:
+        raise RuntimeError(
+            f"parse cache is incomplete: {len(missing)} of {len(pages)} pages absent, "
+            f"first is {missing[0]}"
+        )
+
+
 def prepare(wiki_root: Path, cache_path: Path | None = None) -> dict:
     """Download the pinned model and synchronize every current wiki section."""
     pages = wiki_search.collect_pages(wiki_root, cache_path)
+    if cache_path is not None:
+        verify_parse_cache(cache_path, pages)
     sections = wiki_search.collect_sections(pages)
     model, sqlite_vec, dimension = wiki_search.load_local_embedding_backend()
     connection = wiki_search.open_vector_index(wiki_root, sqlite_vec, dimension)
@@ -71,7 +104,29 @@ def main() -> None:
     cache_path = None
     if args.cache:
         cache_path = args.wiki / ".wiki-cache" / "search-index.json" if args.cache == "AUTO" else Path(args.cache)
-    print(json.dumps(prepare(args.wiki, cache_path), ensure_ascii=False, indent=2))
+    try:
+        payload = prepare(args.wiki, cache_path)
+    except Exception as exc:  # noqa: BLE001 - this is the CLI boundary
+        # Structured on stdout, non-zero on exit: the caller that parses the
+        # ready envelope can parse the failure too, and a shell check still sees
+        # a failure without reading JSON.
+        #
+        # Broad on purpose. The readiness contract promises an envelope on every
+        # failure, and the failures here come from three third-party layers:
+        # sqlite3 (`OperationalError` when the index path is unwritable),
+        # FastEmbed and sqlite-vec (model download, extension loading), and the
+        # filesystem underneath both. Enumerating those exception types means
+        # guessing at other packages' internals, and every wrong guess turns a
+        # documented `{"status": "error"}` back into a traceback. `Exception`
+        # deliberately does not cover KeyboardInterrupt or SystemExit, so Ctrl-C
+        # and explicit exits still behave normally. The type name is kept in the
+        # message so a traceback is not needed to tell the layers apart.
+        detail = str(exc) or repr(exc)
+        message = detail if isinstance(exc, RuntimeError) else f"{type(exc).__name__}: {detail}"
+        print(json.dumps({"status": "error", "wiki": str(args.wiki), "error": message},
+                         ensure_ascii=False, indent=2))
+        raise SystemExit(1)
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
 
 
 if __name__ == "__main__":

--- a/skills/llm-wiki/scripts/wiki_graph_extract.py
+++ b/skills/llm-wiki/scripts/wiki_graph_extract.py
@@ -34,7 +34,6 @@ import argparse
 import hashlib
 import json
 import re
-import sqlite3
 import sys
 import xml.etree.ElementTree as ET
 from collections import defaultdict
@@ -42,6 +41,10 @@ from pathlib import Path
 
 import wiki_markdown
 from wiki_markdown import configure_utf8_streams, extract_wikilinks
+# The SQLite shape is shared with wiki_graph_query.py, which rebuilds the
+# database from the committed exports and cannot import this module (PyYAML).
+from wiki_graph_store import normalize_for_json as _normalize_for_json
+from wiki_graph_store import write_sqlite as _write_sqlite
 
 
 configure_utf8_streams()
@@ -398,16 +401,6 @@ def build_edges(pages: list[dict], slug_to_id: dict[str, str],
 # ---------------------------------------------------------------------------
 
 
-def _normalize_for_json(value):
-    if hasattr(value, "isoformat"):
-        return value.isoformat()
-    if isinstance(value, list):
-        return [_normalize_for_json(v) for v in value]
-    if isinstance(value, dict):
-        return {k: _normalize_for_json(v) for k, v in value.items()}
-    return value
-
-
 def write_jsonl(out_dir: Path, nodes: list[dict], edges: list[dict]) -> None:
     nodes_sorted = sorted(nodes, key=lambda n: n["id"])
     edges_sorted = sorted(edges, key=lambda e: e["id"])
@@ -419,93 +412,6 @@ def write_jsonl(out_dir: Path, nodes: list[dict], edges: list[dict]) -> None:
         for e in edges_sorted:
             f.write(json.dumps(_normalize_for_json(e), sort_keys=True, ensure_ascii=False))
             f.write("\n")
-
-
-def write_sqlite(out_dir: Path, nodes: list[dict], aliases: list[dict], edges: list[dict]) -> None:
-    db_path = out_dir / "graph.sqlite"
-    if db_path.exists():
-        db_path.unlink()
-    conn = sqlite3.connect(db_path)
-    try:
-        conn.executescript("""
-            CREATE TABLE nodes (
-              id TEXT PRIMARY KEY,
-              slug TEXT NOT NULL UNIQUE,
-              title TEXT NOT NULL,
-              page_type TEXT NOT NULL,
-              node_type TEXT NOT NULL,
-              kind TEXT,
-              path TEXT NOT NULL,
-              created TEXT,
-              updated TEXT,
-              metadata_json TEXT NOT NULL
-            );
-            CREATE TABLE aliases (
-              alias TEXT NOT NULL,
-              node_id TEXT NOT NULL,
-              PRIMARY KEY (alias, node_id),
-              FOREIGN KEY (node_id) REFERENCES nodes(id)
-            );
-            CREATE TABLE edges (
-              id TEXT PRIMARY KEY,
-              subject TEXT NOT NULL,
-              predicate TEXT NOT NULL,
-              object TEXT NOT NULL,
-              source TEXT,
-              evidence TEXT,
-              confidence TEXT,
-              status TEXT,
-              extraction_method TEXT NOT NULL,
-              page TEXT NOT NULL,
-              metadata_json TEXT NOT NULL
-            );
-            CREATE INDEX idx_edges_subject ON edges(subject);
-            CREATE INDEX idx_edges_object ON edges(object);
-            CREATE INDEX idx_edges_predicate ON edges(predicate);
-            CREATE INDEX idx_edges_source ON edges(source);
-        """)
-
-        for n in sorted(nodes, key=lambda n: n["id"]):
-            metadata_json = json.dumps(_normalize_for_json({
-                "tags": n.get("tags", []),
-                "aliases": n.get("aliases", []),
-                "canonical": n.get("canonical", False),
-            }), sort_keys=True, ensure_ascii=False)
-            conn.execute(
-                "INSERT INTO nodes (id, slug, title, page_type, node_type, kind, path, created, updated, metadata_json) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    n["id"], n["slug"], n["title"], n["page_type"], n["node_type"],
-                    n.get("kind") or None, n["path"],
-                    str(n.get("created") or "") or None,
-                    str(n.get("updated") or "") or None,
-                    metadata_json,
-                ),
-            )
-
-        for a in sorted(aliases, key=lambda a: (a["alias"], a["node_id"])):
-            conn.execute(
-                "INSERT OR IGNORE INTO aliases (alias, node_id) VALUES (?, ?)",
-                (a["alias"], a["node_id"]),
-            )
-
-        for e in sorted(edges, key=lambda e: e["id"]):
-            metadata_json = json.dumps(_normalize_for_json(e.get("extras") or {}),
-                                       sort_keys=True, ensure_ascii=False)
-            conn.execute(
-                "INSERT INTO edges (id, subject, predicate, object, source, evidence, "
-                "confidence, status, extraction_method, page, metadata_json) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    e["id"], e["subject"], e["predicate"], e["object"],
-                    e.get("source") or None, e.get("evidence") or None,
-                    e.get("confidence") or None, e.get("status") or None,
-                    e["extraction_method"], e["page"], metadata_json,
-                ),
-            )
-        conn.commit()
-    finally:
-        conn.close()
 
 
 def write_graphml(out_dir: Path, nodes: list[dict], edges: list[dict]) -> None:
@@ -598,7 +504,7 @@ def main():
     if "jsonl" in formats:
         write_jsonl(out_dir, nodes, edges)
     if "sqlite" in formats:
-        write_sqlite(out_dir, nodes, aliases, edges)
+        _write_sqlite(out_dir / "graph.sqlite", nodes, aliases, edges)
     if "graphml" in formats:
         write_graphml(out_dir, nodes, edges)
 

--- a/skills/llm-wiki/scripts/wiki_graph_extract.py
+++ b/skills/llm-wiki/scripts/wiki_graph_extract.py
@@ -46,6 +46,9 @@ from wiki_markdown import configure_utf8_streams, extract_wikilinks
 
 configure_utf8_streams()
 
+# Node-id prefix for a cited document that is not itself a wiki page.
+EXTERNAL_DOC_PREFIX = "document:"
+
 try:
     import yaml
 except ImportError:
@@ -198,6 +201,52 @@ def build_nodes(pages: list[dict], ontology: dict) -> tuple[list[dict], dict, li
     return nodes, slug_to_id, aliases
 
 
+def build_document_nodes(pages: list[dict], slug_to_id: dict[str, str]) -> tuple[list[dict], dict]:
+    """Nodes for the external documents that pages cite in `sources:`.
+
+    `sources:` used to be resolved against wiki slugs alone, and every entry
+    that did not resolve was silently dropped. In a wiki whose pages cite
+    repo-relative paths or URLs, that meant the provenance layer was empty and
+    nothing said so: `sourced_from` and `summarizes_raw` both emitted zero
+    edges while lint and the extractor reported success.
+
+    Giving each cited document a node of its own makes provenance a first-class
+    part of the graph — "which pages derive from this doc" becomes a query
+    rather than a grep — and keeps every `sourced_from` edge pointing at
+    something that exists.
+
+    A path that does not exist on disk still gets a node: the graph stays
+    closed, and judging whether the citation is real is `wiki_graph_lint.py`'s
+    job, not the compiler's.
+    """
+    cited: set[str] = set()
+    for p in pages:
+        for entry in p["meta"].get("sources") or []:
+            entry = str(entry).strip()
+            if entry and entry not in slug_to_id:
+                cited.add(entry)
+
+    nodes, ids = [], {}
+    for entry in sorted(cited):
+        node_id = f"{EXTERNAL_DOC_PREFIX}{entry}"
+        ids[entry] = node_id
+        nodes.append({
+            "id": node_id,
+            "slug": entry,
+            "title": entry.rsplit("/", 1)[-1] or entry,
+            "page_type": "",
+            "node_type": "document",
+            "kind": "",
+            "tags": [],
+            "aliases": [],
+            "path": entry,
+            "created": "",
+            "updated": "",
+            "canonical": False,
+        })
+    return nodes, ids
+
+
 def edge_id(subject: str, predicate: str, obj: str, source: str | None, evidence: str | None) -> str:
     # Truncated to 96 bits — collision risk is negligible at any plausible
     # wiki scale and shorter ids keep the JSONL/sqlite/graphml outputs readable.
@@ -224,9 +273,11 @@ def make_edge(*, subject, predicate, obj, source, evidence, confidence, status,
     }
 
 
-def build_edges(pages: list[dict], slug_to_id: dict[str, str]) -> list[dict]:
+def build_edges(pages: list[dict], slug_to_id: dict[str, str],
+                document_ids: dict[str, str] | None = None) -> list[dict]:
     edges: list[dict] = []
     seen_ids: set[str] = set()
+    document_ids = document_ids or {}
 
     def push(edge: dict) -> None:
         if edge["id"] in seen_ids:
@@ -290,23 +341,38 @@ def build_edges(pages: list[dict], slug_to_id: dict[str, str]) -> list[dict]:
                 page=p["rel_path"],
             ))
 
-        # 3. sourced_from edges from frontmatter `sources:` (skip on source pages themselves).
-        if meta.get("type") != "source":
-            for src_slug in meta.get("sources") or []:
-                src_id = slug_to_id.get(str(src_slug))
-                if not src_id:
+        # 3. sourced_from edges from frontmatter `sources:`.
+        for entry in meta.get("sources") or []:
+            entry = str(entry).strip()
+            if not entry:
+                continue
+            target = slug_to_id.get(entry)
+            if target is not None:
+                # On a source page, `sources:` naming another wiki page is not
+                # provenance — the raw file is, and rule 4 below covers it.
+                # The guard is deliberately narrowed to this wiki-slug case: a
+                # source page's citation of an external document IS its
+                # provenance, and skipping source pages wholesale discarded it.
+                if meta.get("type") == "source":
                     continue
-                push(make_edge(
-                    subject=subject_id,
-                    predicate="sourced_from",
-                    obj=src_id,
-                    source=str(src_slug),
-                    evidence=None,
-                    confidence="high",
-                    status="current",
-                    extraction_method="frontmatter_sources",
-                    page=p["rel_path"],
-                ))
+            else:
+                # An external document. Source pages keep this edge: the doc a
+                # source page summarizes is precisely its provenance, and it is
+                # the most load-bearing provenance edge in the graph.
+                target = document_ids.get(entry)
+            if not target or target == subject_id:
+                continue
+            push(make_edge(
+                subject=subject_id,
+                predicate="sourced_from",
+                obj=target,
+                source=entry,
+                evidence=None,
+                confidence="high",
+                status="current",
+                extraction_method="frontmatter_sources",
+                page=p["rel_path"],
+            ))
 
         # 4. summarizes_raw edges from source pages' raw: field.
         if meta.get("type") == "source":
@@ -525,7 +591,9 @@ def main():
 
     pages = collect_pages(args.wiki)
     nodes, slug_to_id, aliases = build_nodes(pages, ontology)
-    edges = build_edges(pages, slug_to_id)
+    document_nodes, document_ids = build_document_nodes(pages, slug_to_id)
+    nodes = nodes + document_nodes
+    edges = build_edges(pages, slug_to_id, document_ids)
 
     if "jsonl" in formats:
         write_jsonl(out_dir, nodes, edges)

--- a/skills/llm-wiki/scripts/wiki_graph_extract.py
+++ b/skills/llm-wiki/scripts/wiki_graph_extract.py
@@ -40,6 +40,12 @@ import xml.etree.ElementTree as ET
 from collections import defaultdict
 from pathlib import Path
 
+import wiki_markdown
+from wiki_markdown import configure_utf8_streams, extract_wikilinks
+
+
+configure_utf8_streams()
+
 try:
     import yaml
 except ImportError:
@@ -51,11 +57,10 @@ except ImportError:
     sys.exit(2)
 
 
-WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "index.md", "log.md", "README.md"}
-SKIP_TOP_LEVEL_DIRS = {"indexes", "graph", "raw"}
+SKIP_TOP_LEVEL_DIRS = wiki_markdown.SKIP_TOP_LEVEL_DIRS
 
 DEFAULT_FORMATS = ["jsonl", "sqlite", "graphml"]
 
@@ -94,7 +99,7 @@ def collect_pages(wiki_root: Path) -> list[dict]:
         except (UnicodeDecodeError, OSError):
             continue
         meta, body = parse_frontmatter(text)
-        links = [m.group(1).strip() for m in WIKILINK_RE.finditer(body)]
+        links = extract_wikilinks(body)
         pages.append({
             "path": str(md_path),
             "rel_path": str(rel).replace("\\", "/"),

--- a/skills/llm-wiki/scripts/wiki_graph_lint.py
+++ b/skills/llm-wiki/scripts/wiki_graph_lint.py
@@ -43,6 +43,12 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+import wiki_markdown
+from wiki_markdown import configure_utf8_streams, extract_wikilinks
+
+
+configure_utf8_streams()
+
 try:
     import yaml
 except ImportError:
@@ -61,10 +67,9 @@ import wiki_graph_extract as _extract  # noqa: E402
 
 
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
-WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "index.md", "log.md", "README.md"}
-SKIP_TOP_LEVEL_DIRS = {"indexes", "graph", "raw"}
+SKIP_TOP_LEVEL_DIRS = wiki_markdown.SKIP_TOP_LEVEL_DIRS
 
 ALLOWED_CONFIDENCE = {"high", "medium", "low"}
 ALLOWED_STATUS = {"current", "historical", "proposed", "disputed", "superseded"}
@@ -105,7 +110,7 @@ def collect_pages(wiki_root: Path) -> list[dict]:
             "slug": md_path.stem,
             "meta": meta,
             "body": body,
-            "links": [m.group(1).strip() for m in WIKILINK_RE.finditer(body)],
+            "links": extract_wikilinks(body),
         })
     return pages
 

--- a/skills/llm-wiki/scripts/wiki_graph_lint.py
+++ b/skills/llm-wiki/scripts/wiki_graph_lint.py
@@ -273,9 +273,13 @@ def lint(pages: list[dict], ontology: dict) -> dict:
                 if not rel.get("source"):
                     findings["missing_source_field"].append({**here})
 
-            # source field must reference an existing source page slug
+            # source field must reference an existing source page slug, or the
+            # subject page's own slug. SCHEMA documents the field as a
+            # "source/derived page slug": a derived page may cite itself as the
+            # provenance of an edge it declares, and rejecting that made every
+            # such edge a lint failure with no correct way to write it.
             src = rel.get("source")
-            if src and str(src) not in source_slugs:
+            if src and str(src) not in source_slugs and str(src) != p["slug"]:
                 findings["broken_source_refs"].append({**here, "source": src})
 
             confidence = rel.get("confidence")
@@ -419,6 +423,12 @@ def main():
         print(json.dumps(findings, indent=2, default=str))
     else:
         print(render_text(findings))
+
+    # Same reason as wiki_lint.py: a gate needs an exit code, not a report to
+    # re-parse. A broken typed edge is a defect in the graph, not a suggestion.
+    if any(value for key, value in findings.items()
+           if key != "summary" and isinstance(value, list)):
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/skills/llm-wiki/scripts/wiki_graph_lint.py
+++ b/skills/llm-wiki/scripts/wiki_graph_lint.py
@@ -153,8 +153,9 @@ def types_match(allowed: list[str] | None, actual: str | None) -> bool:
     return actual in allowed
 
 
-def lint(pages: list[dict], ontology: dict) -> dict:
+def lint(pages: list[dict], ontology: dict, repo_root: Path | None = None) -> dict:
     findings = {
+        "unresolved_sources": [],
         "duplicate_node_ids": [],
         "unknown_predicates": [],
         "broken_object_refs": [],
@@ -302,7 +303,30 @@ def lint(pages: list[dict], ontology: dict) -> dict:
     # Orphan typed nodes — pages that declared `graph:` frontmatter but end
     # up with no typed (non-implicit) edge touching them after extraction.
     # Source nodes are exempt (they participate via implicit edges).
-    extracted_edges = _extract.build_edges(pages, {n["slug"]: n["id"] for n in node_by_id.values()})
+    slug_to_id = {n["slug"]: n["id"] for n in node_by_id.values()}
+
+    # Every `sources:` entry must name something real — a wiki page slug or a
+    # file in the repo. This exists because the failure it catches is silent by
+    # construction: an entry that resolves to neither still compiles into a
+    # document node and a `sourced_from` edge, so the graph looks populated
+    # while the provenance points at nothing. Skipped when the repo root is
+    # unknown, since then "file on disk" cannot be decided.
+    if repo_root is not None:
+        for p in pages:
+            for index, entry in enumerate(p["meta"].get("sources") or []):
+                entry = str(entry).strip()
+                if not entry or entry in slug_to_id:
+                    continue
+                if (repo_root / entry).exists():
+                    continue
+                findings["unresolved_sources"].append({
+                    "page": p["rel_path"],
+                    "index": index,
+                    "source": entry,
+                })
+
+    _document_nodes, document_ids = _extract.build_document_nodes(pages, slug_to_id)
+    extracted_edges = _extract.build_edges(pages, slug_to_id, document_ids)
     typed_node_refs: set[str] = set()
     for e in extracted_edges:
         if e["predicate"] in IMPLICIT_PREDICATES:
@@ -343,6 +367,8 @@ def render_text(findings: dict) -> str:
     out.append("")
 
     sections = [
+        ("unresolved_sources", "sources: entry is neither a wiki slug nor a file in the repo",
+         lambda f: f"  - {f['page']}#sources[{f['index']}]  {f['source']!r}"),
         ("duplicate_node_ids", "Duplicate node ids",
          lambda f: f"  - {f['node_id']}: {', '.join(f['paths'])}"),
         ("unknown_predicates", "Unknown predicates (not in ontology)",
@@ -417,7 +443,7 @@ def main():
         sys.exit(2)
 
     pages = collect_pages(args.wiki)
-    findings = lint(pages, ontology)
+    findings = lint(pages, ontology, repo_root=args.wiki.resolve().parent)
 
     if args.json:
         print(json.dumps(findings, indent=2, default=str))

--- a/skills/llm-wiki/scripts/wiki_graph_query.py
+++ b/skills/llm-wiki/scripts/wiki_graph_query.py
@@ -33,6 +33,7 @@ import sys
 from collections import deque
 from pathlib import Path
 
+import wiki_graph_store
 from wiki_markdown import configure_utf8_streams
 
 configure_utf8_streams()
@@ -41,9 +42,47 @@ configure_utf8_streams()
 EVIDENCE_SNIPPET_LEN = 140
 
 
-def open_db(path: Path) -> sqlite3.Connection:
+def rebuild_reason(db_path: Path, graph_dir: Path) -> str | None:
+    """Why the database needs rebuilding from the exports, or None if it does not."""
+    nodes_path, edges_path = wiki_graph_store.export_paths(graph_dir)
+    if not (nodes_path.exists() and edges_path.exists()):
+        return None                       # nothing to rebuild from; caller reports it
+    if not db_path.exists():
+        return "missing"
+    db_mtime = db_path.stat().st_mtime
+    if max(nodes_path.stat().st_mtime, edges_path.stat().st_mtime) > db_mtime:
+        return "older than the exports"
+    return None
+
+
+def open_db(path: Path, graph_dir: Path) -> sqlite3.Connection:
+    """Open the graph, compiling it from the committed exports when needed.
+
+    `graph.sqlite` is derived and gitignored, so a fresh clone has the exports
+    but no database. Before this, every query here failed and the agent simply
+    skipped the graph step — the wiki still answered, just without typed
+    neighbours, and nothing said a whole retrieval stage had gone missing.
+    Silent degradation is worse than the two seconds a rebuild costs.
+
+    Only the JSONL exports are read, never the markdown: this script is
+    stdlib-only by design and must not acquire PyYAML or `uv`. Whether those
+    exports still match the pages is `wiki_graph_check.py`'s question.
+    """
+    reason = rebuild_reason(path, graph_dir)
+    if reason:
+        print(f"graph.sqlite {reason}; rebuilding from {graph_dir}/nodes.jsonl + edges.jsonl",
+              file=sys.stderr)
+        try:
+            nodes, aliases, edges = wiki_graph_store.read_exports(graph_dir)
+            wiki_graph_store.write_sqlite(path, nodes, aliases, edges)
+        except (OSError, ValueError, sqlite3.Error) as exc:
+            print(f"Rebuild failed: {exc}", file=sys.stderr)
+            print("Run wiki_graph_extract.py to regenerate the graph.", file=sys.stderr)
+            sys.exit(1)
+        print(f"  {len(nodes)} nodes, {len(edges)} edges", file=sys.stderr)
     if not path.exists():
-        print(f"graph.sqlite not found at {path}.", file=sys.stderr)
+        print(f"graph.sqlite not found at {path}, and no exports to rebuild it from.",
+              file=sys.stderr)
         print("Run wiki_graph_extract.py first.", file=sys.stderr)
         sys.exit(1)
     conn = sqlite3.connect(path)
@@ -240,8 +279,9 @@ def main():
     if not args.wiki.exists():
         print(f"Wiki directory not found: {args.wiki}", file=sys.stderr)
         sys.exit(1)
-    db_path = args.db or (args.wiki / "graph" / "graph.sqlite")
-    conn = open_db(db_path)
+    graph_dir = args.wiki / "graph"
+    db_path = args.db or (graph_dir / "graph.sqlite")
+    conn = open_db(db_path, graph_dir)
     try:
         if args.command == "neighbors":
             result = cmd_neighbors(conn, args)

--- a/skills/llm-wiki/scripts/wiki_graph_query.py
+++ b/skills/llm-wiki/scripts/wiki_graph_query.py
@@ -33,6 +33,10 @@ import sys
 from collections import deque
 from pathlib import Path
 
+from wiki_markdown import configure_utf8_streams
+
+configure_utf8_streams()
+
 
 EVIDENCE_SNIPPET_LEN = 140
 

--- a/skills/llm-wiki/scripts/wiki_graph_query.py
+++ b/skills/llm-wiki/scripts/wiki_graph_query.py
@@ -3,43 +3,109 @@
 wiki_graph_query.py — Query the compiled wiki graph (graph.sqlite).
 
 Use this to accelerate navigation: find what's connected to a node, list
-typed edges around a subject, find a path between two nodes, or dump every
-fact about a node. The graph is a navigation index — for high-stakes
-claims, follow the `source` field back to the wiki page and the raw file.
+typed edges around a subject, find what a set of pages has in common, find a
+path between two nodes, or dump every fact about a node. The graph is a
+navigation index — for high-stakes claims, follow the `source` field back to
+the wiki page and the raw file.
+
+Every subcommand takes an id, a bare page slug (what `wiki_search.py` reports)
+or a unique alias.
 
 Subcommands:
     neighbors --node <id>            List nodes one hop away from <id>
     edges    --subject <id>          List all outbound edges from <id>
              [--predicate <p>]        Filter by predicate
+    subgraph --nodes <id,id,...>     The subgraph BOUNDED BY these terms: the
+                                      terms, plus everything on the routes
+                                      between them. Three layers, weakest last —
+                                      direct edges inside the set; shared
+                                      connectors (one node two or more members
+                                      reach); and chains, the route between a
+                                      pair that has neither. Distant terms have
+                                      only the chain, so this answers "how are
+                                      these related" at any distance, in one call
+             [--predicate <p>]        Filter the reported edges
+             [--radius N]             Hops from each member when hunting
+                                      connectors. Default 1, widening to 2 only
+                                      if that finds nothing; 0 = induced only
+             [--max-chain-hops N]     Longest route reported (default 4). A pair
+                                      further apart is reported with its true
+                                      distance, never as "unrelated"
+             [--max-connector-degree N]  Skip connectors adjacent to more than N
+                                      nodes (default 25, 0 = keep all). Skipped
+                                      hubs are reported, never hidden
+             [--include-mentions]     Allow implicit `mentions` routes too
     path     --from <id> --to <id>   Shortest directed path (BFS, max depth 6)
              [--max-depth N]
     facts    --about <id>            Outbound + inbound edges for <id>
 
 Common options:
     --db <path>           Path to graph.sqlite (default: <wiki>/graph/graph.sqlite)
-    --json                Emit JSON instead of text
+    --json                Emit JSON instead of text (goes before the subcommand)
 
 Examples:
     python wiki_graph_query.py wiki/ neighbors --node product:konvy
     python wiki_graph_query.py wiki/ edges    --subject person:stephanie-emmanouel
+    python wiki_graph_query.py wiki/ subgraph --nodes kv-cache,quantization
     python wiki_graph_query.py wiki/ path     --from person:praney-behl --to product:konvy
     python wiki_graph_query.py wiki/ facts    --about product:konvy
 """
 
 import argparse
+import itertools
 import json
 import sqlite3
 import sys
-from collections import deque
+from collections import defaultdict, deque
 from pathlib import Path
 
 import wiki_graph_store
 from wiki_markdown import configure_utf8_streams
 
+
 configure_utf8_streams()
 
 
 EVIDENCE_SNIPPET_LEN = 140
+
+# Connector hunting walks typed edges only. Implicit `mentions` edges were 72%
+# of the graph measured below and carry no evidence, and a route through one is
+# routinely spurious: two specialised pages "connected" because both happen to
+# link the same overview page, while their real shared step is a third concept
+# neither of them names. `--include-mentions` widens it when that is wanted.
+CONNECTOR_PREDICATES = (
+    "relates_to", "depends_on", "alternative_to", "specializes", "constrains", "supersedes",
+)
+# Measured on a 570-page wiki: 228 nodes carry typed edges, degrees run 1–17
+# with a median of 3, and one registry page sits at 196. A node adjacent to a
+# quarter of the corpus puts every pair at distance 2 — it produced ~700k
+# "indirectly related" triples against 30 that go through a substantive
+# connector. So a hub is a bad connector by construction, not by topic. 25
+# clears the highest legitimate degree observed and stays far below the hub;
+# 0 disables the filter.
+DEFAULT_MAX_CONNECTOR_DEGREE = 25
+# Radius 1 finds the shared-intermediate shape (two members at distance 2).
+# Escalating to 2 covers two intermediates, at the cost of much weaker claims —
+# so it is tried only when radius 1 finds nothing at all.
+MAX_AUTO_RADIUS = 2
+# Distant terms have no shared neighbour to find: the relationship *is* a chain.
+# Which edges a chain may walk decides whether the question is answerable at all.
+# Measured here, hub-free, over random concept pairs:
+#
+#   typed only            8% reachable, 41 components — cannot answer
+#   typed + mentions     74% reachable within 6 hops (41% within 4)
+#   every predicate     shorter routes, but they run through `document` nodes of
+#                       degree up to 600; "both are written about in the same
+#                       file" is provenance, not a relationship
+#   no hub cap          everything two hops apart via the registry page
+#
+# So the widened scope is page-to-page: typed plus `mentions`, never `sourced_from`.
+CHAIN_PREDICATES = CONNECTOR_PREDICATES + ("mentions",)
+# 4 hops is the edge of a claim: beyond it a wikilink chain is a chain of
+# coincidences. A pair whose route is longer is reported with its true distance
+# rather than as "unrelated", so the caller can raise the limit deliberately.
+DEFAULT_MAX_CHAIN_HOPS = 4
+CHAIN_PROBE_HOPS = 8
 
 
 def rebuild_reason(db_path: Path, graph_dir: Path) -> str | None:
@@ -66,7 +132,7 @@ def open_db(path: Path, graph_dir: Path) -> sqlite3.Connection:
 
     Only the JSONL exports are read, never the markdown: this script is
     stdlib-only by design and must not acquire PyYAML or `uv`. Whether those
-    exports still match the pages is `wiki_graph_check.py`'s question.
+    exports still match the pages is a separate question, and a separate tool's.
     """
     reason = rebuild_reason(path, graph_dir)
     if reason:
@@ -115,6 +181,238 @@ def edges_to(conn: sqlite3.Connection, obj: str, predicate: str | None = None) -
     return [dict(r) for r in conn.execute(q, params).fetchall()]
 
 
+def resolve_node_id(conn: sqlite3.Connection, token: str) -> str | None:
+    """Accept a graph id, a bare page slug, or an alias.
+
+    `subgraph` is fed from a retrieval result set, and `wiki_search.py` reports
+    `slug` — not `<node_type>:<slug>`. Making the caller rebuild the namespace by
+    hand is the one thing that would keep this command out of the workflow it
+    exists for. `slug` is UNIQUE in the schema, so that lookup is unambiguous;
+    an alias is not, so it resolves only when it names exactly one node. An
+    ambiguous alias stays unresolved and is reported rather than silently
+    picking a node for the caller.
+    """
+    if conn.execute("SELECT 1 FROM nodes WHERE id = ?", (token,)).fetchone():
+        return token
+    row = conn.execute("SELECT id FROM nodes WHERE slug = ?", (token,)).fetchone()
+    if row:
+        return row["id"]
+    candidates = conn.execute(
+        "SELECT node_id FROM aliases WHERE alias = ? ORDER BY node_id", (token,)
+    ).fetchall()
+    return candidates[0]["node_id"] if len(candidates) == 1 else None
+
+
+def require_node_id(conn: sqlite3.Connection, token: str, label: str = "node") -> str:
+    """Resolve or exit. Every subcommand accepts an id, a slug or a unique alias."""
+    node_id = resolve_node_id(conn, token)
+    if node_id is None:
+        print(f"{label} not found: {token} "
+              "(accepts a graph id, a page slug, or a unique alias)", file=sys.stderr)
+        sys.exit(1)
+    return node_id
+
+
+def undirected_adjacency(conn: sqlite3.Connection,
+                         predicates: tuple[str, ...] | None) -> dict[str, set[str]]:
+    """Neighbour map for connector hunting, direction discarded.
+
+    Undirected on purpose. `A depends_on X` and `B relates_to X` is exactly the
+    shape of a shared dependency, and no directed walk can see it — leaving X
+    for B means going against the arrow. Direction survives in the edges that
+    get reported; only the reachability question ignores it.
+    """
+    query = "SELECT subject, object FROM edges"
+    params: list = []
+    if predicates:
+        query += f" WHERE predicate IN ({','.join('?' for _ in predicates)})"
+        params.extend(predicates)
+    adjacency: dict[str, set[str]] = defaultdict(set)
+    for subject, obj in conn.execute(query, params):
+        adjacency[subject].add(obj)
+        adjacency[obj].add(subject)
+    return adjacency
+
+
+def find_connectors(adjacency: dict[str, set[str]], node_ids: list[str],
+                    radius: int, max_degree: int) -> tuple[dict[str, dict], dict[str, int]]:
+    """Nodes outside the set that sit within `radius` hops of two or more members.
+
+    "Common" is the whole question: a node reachable from one member explains
+    nothing about the set, a node reachable from several is the shared step. Each
+    member's own neighbourhood is walked once, so cost is linear in members
+    rather than quadratic in pairs.
+
+    Returns (connectors, excluded_hubs) — the hubs are returned rather than
+    dropped silently, because "the only thing joining these pages is a registry
+    every page touches" is itself the answer to some questions.
+    """
+    members = set(node_ids)
+    reach: dict[str, dict[str, int]] = {}
+    for member in node_ids:
+        seen = {member: 0}
+        queue = deque([(member, 0)])
+        while queue:
+            node, hops = queue.popleft()
+            if hops >= radius:
+                continue
+            for neighbour in adjacency.get(node, ()):
+                if neighbour in seen:
+                    continue
+                seen[neighbour] = hops + 1
+                # A hub is barred from the walk, not just from the candidate list.
+                # Letting it be traversed makes it a bridge: every one of the 196
+                # neighbours of `concept:test-unit-registry` becomes "reachable
+                # from all three members" at radius 2, and the command answers a
+                # relational question with the entire corpus. Recorded in `seen`
+                # first, so it can still be reported as a skipped candidate.
+                if max_degree and len(adjacency.get(neighbour, ())) > max_degree:
+                    continue
+                queue.append((neighbour, hops + 1))
+        for node, hops in seen.items():
+            if hops and node not in members:
+                reach.setdefault(node, {})[member] = hops
+    connectors: dict[str, dict] = {}
+    excluded_hubs: dict[str, int] = {}
+    for node, joins in reach.items():
+        if len(joins) < 2:
+            continue
+        degree = len(adjacency.get(node, ()))
+        if max_degree and degree > max_degree:
+            excluded_hubs[node] = degree
+        else:
+            connectors[node] = {"joins": joins, "degree": degree}
+    return connectors, excluded_hubs
+
+
+def shortest_chain(adjacency: dict[str, set[str]], source: str, target: str,
+                   max_hops: int, max_degree: int) -> list[str]:
+    """Shortest hub-free node path from `source` to `target`, or []."""
+    if source == target:
+        return []
+    queue = deque([source])
+    parent: dict[str, str | None] = {source: None}
+    depth = {source: 0}
+    while queue:
+        node = queue.popleft()
+        if depth[node] >= max_hops:
+            continue
+        for neighbour in adjacency.get(node, ()):
+            if neighbour in parent:
+                continue
+            parent[neighbour] = node
+            depth[neighbour] = depth[node] + 1
+            if neighbour == target:
+                path = [target]
+                while parent[path[-1]] is not None:
+                    path.append(parent[path[-1]])
+                return list(reversed(path))
+            # Same rule as connector hunting: a hub is not a route. Without this
+            # every pair is "two hops apart" through the registry page.
+            if max_degree and len(adjacency.get(neighbour, ())) > max_degree:
+                continue
+            queue.append(neighbour)
+    return []
+
+
+def chain_edges(conn: sqlite3.Connection, path: list[str]) -> list[dict]:
+    """The edges realising a chain, in walk order, direction as recorded."""
+    edges = []
+    for left, right in zip(path, path[1:]):
+        rows = conn.execute(
+            "SELECT * FROM edges WHERE (subject = ? AND object = ?) "
+            "OR (subject = ? AND object = ?) ORDER BY predicate DESC, id",
+            (left, right, right, left),
+        ).fetchall()
+        if rows:
+            edges.append(dict(rows[0]))
+    return edges
+
+
+def find_chains(conn: sqlite3.Connection, scopes: list[tuple[str, dict[str, set[str]]]],
+                pairs: list[tuple[str, str]], max_hops: int,
+                max_degree: int) -> tuple[list[dict], list[tuple[str, str]]]:
+    """The routes between the given terms — the subgraph they bound.
+
+    One shortest chain per pair. `scopes` are tried in order per pair, not
+    globally: the typed layer reaches only 8% of random concept pairs here, so a
+    single strict pass would report "unrelated" for almost everything, while a
+    single wide pass would hide that a route exists only through wikilinks.
+    Each chain therefore records which scope found it and its weakest predicate.
+
+    Ordered by hop count — a two-hop route is a claim, a four-hop route is a lead.
+    Returns (chains, pairs still unreachable).
+    """
+    chains = []
+    unreachable = []
+    for source, target in pairs:
+        for scope_name, adjacency in scopes:
+            path = shortest_chain(adjacency, source, target, max_hops, max_degree)
+            if not path:
+                # Silence here would read as "unrelated". Probe further so the
+                # answer can be "related, but further away than you asked for".
+                probe = shortest_chain(adjacency, source, target,
+                                       CHAIN_PROBE_HOPS, max_degree)
+                if probe and scope_name == scopes[-1][0]:
+                    unreachable.append({"from": source, "to": target,
+                                        "beyond_limit_hops": len(probe) - 1,
+                                        "scope": scope_name})
+                continue
+            edges = chain_edges(conn, path)
+            chains.append({
+                "from": source,
+                "to": target,
+                "hops": len(path) - 1,
+                "nodes": path,
+                "via": path[1:-1],
+                "edges": edges,
+                "scope": scope_name,
+                "weakest": "mentions" if any(edge["predicate"] == "mentions"
+                                             for edge in edges) else "typed",
+            })
+            break
+    chains.sort(key=lambda chain: (chain["hops"], chain["from"], chain["to"]))
+    return chains, unreachable
+
+
+def induced_edges(conn: sqlite3.Connection, node_ids: list[str],
+                  predicate: str | None = None) -> list[dict]:
+    """Edges whose subject AND object are both in `node_ids`.
+
+    A temp table rather than two `IN (...)` lists: the set is a retrieval result
+    of caller-chosen size, and 2N bound parameters would eventually hit
+    SQLITE_MAX_VARIABLE_NUMBER. Both joins ride the subject/object indexes.
+    """
+    conn.execute("CREATE TEMP TABLE IF NOT EXISTS subgraph_nodes (id TEXT PRIMARY KEY)")
+    conn.execute("DELETE FROM subgraph_nodes")
+    conn.executemany(
+        "INSERT OR IGNORE INTO subgraph_nodes(id) VALUES (?)",
+        ((node_id,) for node_id in node_ids),
+    )
+    query = (
+        "SELECT edges.* FROM edges "
+        "JOIN subgraph_nodes AS subjects ON subjects.id = edges.subject "
+        "JOIN subgraph_nodes AS objects ON objects.id = edges.object"
+    )
+    params: list = []
+    if predicate:
+        query += " WHERE edges.predicate = ?"
+        params.append(predicate)
+    query += " ORDER BY edges.subject, edges.predicate, edges.object"
+    return [dict(row) for row in conn.execute(query, params).fetchall()]
+
+
+def split_node_tokens(values: list[str] | None) -> list[str]:
+    """Flatten repeated `--nodes` flags and comma lists into ordered unique tokens."""
+    tokens: list[str] = []
+    for value in values or []:
+        for token in value.split(","):
+            token = token.strip()
+            if token and token not in tokens:
+                tokens.append(token)
+    return tokens
+
+
 def truncate(text: str | None) -> str:
     if not text:
         return ""
@@ -138,12 +436,10 @@ def render_edge_row(e: dict) -> str:
 
 
 def cmd_neighbors(conn: sqlite3.Connection, args) -> dict:
-    node = fetch_node(conn, args.node)
-    if not node:
-        print(f"node not found: {args.node}", file=sys.stderr)
-        sys.exit(1)
-    out_edges = edges_from(conn, args.node)
-    in_edges = edges_to(conn, args.node)
+    node_id = require_node_id(conn, args.node)
+    node = fetch_node(conn, node_id)
+    out_edges = edges_from(conn, node_id)
+    in_edges = edges_to(conn, node_id)
 
     neighbors: dict[str, dict] = {}
     for e in out_edges:
@@ -166,33 +462,136 @@ def cmd_neighbors(conn: sqlite3.Connection, args) -> dict:
 
 
 def cmd_edges(conn: sqlite3.Connection, args) -> dict:
-    es = edges_from(conn, args.subject, args.predicate)
-    return {"subject": args.subject, "predicate": args.predicate, "edges": es}
+    subject = require_node_id(conn, args.subject, "subject")
+    return {"subject": subject, "predicate": args.predicate,
+            "edges": edges_from(conn, subject, args.predicate)}
+
+
+def cmd_subgraph(conn: sqlite3.Connection, args) -> dict:
+    """The subgraph bounded by a set of terms: the terms plus the routes between them.
+
+    Three layers, weakest claim last:
+
+      edges       direct relationships inside the set
+      connectors  one node reached from two or more members — a shared step
+      chains      the route between a pair that has neither, which for distant
+                  terms is the only thing that exists
+
+    Node order follows the tokens as given, because the set normally arrives as a
+    ranked retrieval result and that ranking is information. The negatives are
+    load-bearing too: `isolated` and `unreachable` say "these terms are not
+    related in this wiki", which is a finding, not an empty result.
+    """
+    requested = split_node_tokens(args.nodes)
+    if not requested:
+        print("no nodes given: pass --nodes <id,id,...>", file=sys.stderr)
+        sys.exit(2)
+    resolved: dict[str, str] = {}
+    unresolved: list[str] = []
+    for token in requested:
+        node_id = resolve_node_id(conn, token)
+        if node_id is None:
+            unresolved.append(token)
+        else:
+            resolved.setdefault(node_id, token)
+    if not resolved:
+        print(f"none of the requested nodes are in the graph: {', '.join(unresolved)}",
+              file=sys.stderr)
+        sys.exit(1)
+    node_ids = list(resolved)
+    connectors: dict[str, dict] = {}
+    excluded_hubs: dict[str, int] = {}
+    radius_used = 0
+    adjacency: dict[str, set[str]] | None = None
+    # `--radius` unset means "find the connection, whatever its distance": try the
+    # strong claim first and widen only if it finds nothing. An explicit value is
+    # obeyed exactly, and 0 asks for the induced subgraph alone.
+    attempts = [1, MAX_AUTO_RADIUS] if args.radius is None else [args.radius]
+    if any(attempts):
+        # `--predicate` narrows discovery too, not just the printed edges: a
+        # connector found over other predicates would come back with none of its
+        # joining edges shown, which reads as a bug.
+        if args.predicate:
+            predicates: tuple[str, ...] | None = (args.predicate,)
+        else:
+            predicates = None if args.include_mentions else CONNECTOR_PREDICATES
+        adjacency = undirected_adjacency(conn, predicates)
+        for radius in attempts:
+            if radius <= 0:
+                continue
+            radius_used = radius
+            connectors, excluded_hubs = find_connectors(
+                adjacency, node_ids, radius, args.max_connector_degree
+            )
+            if connectors:
+                break
+    ordered_connectors = sorted(
+        connectors, key=lambda node: (-len(connectors[node]["joins"]),
+                                      connectors[node]["degree"], node)
+    )
+    # The routes between the terms are the subgraph they bound. A shared connector
+    # is the degenerate two-hop case of one; distant terms have only the chain.
+    chains: list[dict] = []
+    unreachable: list[dict] = []
+    if args.max_chain_hops and len(node_ids) > 1:
+        scopes = [("typed", adjacency if adjacency is not None
+                   else undirected_adjacency(conn, CONNECTOR_PREDICATES))]
+        if not args.predicate and not args.include_mentions:
+            # Widened per pair, not globally — see find_chains.
+            scopes.append(("typed+mentions", undirected_adjacency(conn, CHAIN_PREDICATES)))
+        chains, unreachable = find_chains(
+            conn, scopes, list(itertools.combinations(node_ids, 2)),
+            args.max_chain_hops, args.max_connector_degree,
+        )
+    route_nodes: list[str] = []
+    for chain in chains:
+        for node in chain["via"]:
+            if node not in route_nodes and node not in resolved:
+                route_nodes.append(node)
+    edges = induced_edges(conn, node_ids + ordered_connectors + route_nodes, args.predicate)
+    connected = {edge["subject"] for edge in edges} | {edge["object"] for edge in edges}
+    return {
+        "requested": requested,
+        "unresolved": unresolved,
+        "predicate": args.predicate,
+        "radius": radius_used,
+        "include_mentions": bool(args.include_mentions),
+        "nodes": [fetch_node(conn, node_id) for node_id in node_ids],
+        "connectors": [
+            {**(fetch_node(conn, node) or {"id": node}),
+             "degree": connectors[node]["degree"],
+             "joins": connectors[node]["joins"]}
+            for node in ordered_connectors
+        ],
+        "chains": [
+            {**chain,
+             "titles": [(fetch_node(conn, node) or {}).get("title", node)
+                        for node in chain["nodes"]]}
+            for chain in chains
+        ],
+        "unreachable": unreachable,
+        "edges": edges,
+        "isolated": [node_id for node_id in node_ids if node_id not in connected],
+        "excluded_hubs": [
+            {"id": node, "degree": degree,
+             "title": (fetch_node(conn, node) or {}).get("title", node)}
+            for node, degree in sorted(excluded_hubs.items(), key=lambda kv: -kv[1])
+        ],
+    }
 
 
 def cmd_facts(conn: sqlite3.Connection, args) -> dict:
-    node = fetch_node(conn, args.about)
-    if not node:
-        print(f"node not found: {args.about}", file=sys.stderr)
-        sys.exit(1)
+    node_id = require_node_id(conn, args.about)
     return {
-        "node": node,
-        "outbound": edges_from(conn, args.about),
-        "inbound": edges_to(conn, args.about),
+        "node": fetch_node(conn, node_id),
+        "outbound": edges_from(conn, node_id),
+        "inbound": edges_to(conn, node_id),
     }
 
 
 def cmd_path(conn: sqlite3.Connection, args) -> dict:
-    src = fetch_node(conn, getattr(args, "from"))
-    dst = fetch_node(conn, args.to)
-    if not src:
-        print(f"from-node not found: {getattr(args, 'from')}", file=sys.stderr)
-        sys.exit(1)
-    if not dst:
-        print(f"to-node not found: {args.to}", file=sys.stderr)
-        sys.exit(1)
-
-    start, goal = getattr(args, "from"), args.to
+    start = require_node_id(conn, getattr(args, "from"), "from-node")
+    goal = require_node_id(conn, args.to, "to-node")
     queue = deque([(start, [start], [])])
     visited = {start}
     while queue:
@@ -229,6 +628,66 @@ def render(result: dict, command: str) -> str:
         for e in result["edges"]:
             out.append("")
             out.append(render_edge_row(e))
+    elif command == "subgraph":
+        header = f"Subgraph over {len(result['nodes'])} nodes"
+        if result["predicate"]:
+            header += f", predicate {result['predicate']}"
+        if result["radius"]:
+            header += f", connector radius {result['radius']}"
+        if result["include_mentions"]:
+            header += ", mentions included"
+        out.append(header)
+        for node in result["nodes"]:
+            out.append(f"  {node['id']}  ({node['title']})  [{node['path']}]")
+        if result["connectors"]:
+            out.append("")
+            out.append(f"Shared connectors ({len(result['connectors'])}) — not in the set, "
+                       "reached from two or more members:")
+            for connector in result["connectors"]:
+                joins = ", ".join(
+                    f"{member.split(':', 1)[-1]} ({hops}h)"
+                    for member, hops in sorted(connector["joins"].items())
+                )
+                out.append("")
+                out.append(f"  ★ {connector['id']}  ({connector.get('title')})")
+                out.append(f"      joins {len(connector['joins'])}: {joins}")
+                out.append(f"      degree {connector['degree']}  [{connector.get('path')}]")
+        if result.get("chains"):
+            out.append("")
+            out.append(f"Routes between the terms ({len(result['chains'])}) — the subgraph "
+                       "they bound:")
+            for chain in result["chains"]:
+                arrow = "  " + " → ".join(node.split(":", 1)[-1] for node in chain["nodes"])
+                out.append("")
+                out.append(f"{arrow}   [{chain['hops']} hops, {chain['scope']}, "
+                           f"weakest link: {chain['weakest']}]")
+                for step, edge in enumerate(chain["edges"], 1):
+                    quote = f"  — {truncate(edge['evidence'])}" if edge["evidence"] else ""
+                    out.append(f"      {step}. [{edge['predicate']}] "
+                               f"conf={edge.get('confidence') or '-'}{quote}")
+        if result.get("unreachable"):
+            out.append("")
+            out.append("Related, but further than the hop limit:")
+            for gap in result["unreachable"]:
+                out.append(f"  {gap['from']} ⇄ {gap['to']} — shortest route is "
+                           f"{gap['beyond_limit_hops']} hops "
+                           "(raise --max-chain-hops to see it)")
+        out.append("")
+        out.append(f"Edges within the set and its connectors ({len(result['edges'])}):")
+        for e in result["edges"]:
+            out.append("")
+            out.append(render_edge_row(e))
+        if result["isolated"]:
+            out.append("")
+            out.append("Unconnected even through a connector: " + ", ".join(result["isolated"]))
+        if result["excluded_hubs"]:
+            out.append("")
+            out.append("Hubs skipped as connectors (too general to explain anything):")
+            for hub in result["excluded_hubs"]:
+                out.append(f"  {hub['id']}  degree {hub['degree']}  ({hub['title']})")
+        if result["unresolved"]:
+            out.append("")
+            out.append("Not in the graph: " + ", ".join(result["unresolved"]))
     elif command == "facts":
         n = result["node"]
         out.append(f"Facts about {n['id']}  ({n['title']})  [{n['path']}]")
@@ -266,6 +725,27 @@ def main():
     p_e.add_argument("--subject", required=True)
     p_e.add_argument("--predicate")
 
+    p_s = sub.add_parser("subgraph")
+    p_s.add_argument("--nodes", action="append", required=True,
+                     help="Comma-separated ids, slugs or aliases; repeatable.")
+    p_s.add_argument("--predicate")
+    p_s.add_argument("--radius", type=int, default=None,
+                     help="Hops from each member when hunting shared connectors. "
+                          f"Default: 1, widening to {MAX_AUTO_RADIUS} only if that finds "
+                          "nothing. 0 = induced subgraph only.")
+    p_s.add_argument("--max-connector-degree", type=int,
+                     default=DEFAULT_MAX_CONNECTOR_DEGREE,
+                     help="Drop connectors adjacent to more than N nodes "
+                          f"(default {DEFAULT_MAX_CONNECTOR_DEGREE}; 0 = keep all). "
+                          "They are reported, not hidden.")
+    p_s.add_argument("--include-mentions", action="store_true",
+                     help="Allow implicit `mentions` edges as connector routes.")
+    p_s.add_argument("--max-chain-hops", type=int, default=DEFAULT_MAX_CHAIN_HOPS,
+                     help="Longest route reported between two terms "
+                          f"(default {DEFAULT_MAX_CHAIN_HOPS}; 0 = no routes). The typed "
+                          "layer reaches 8%% of concept pairs here, so a route may widen "
+                          "to `mentions` — each one says which scope found it.")
+
     p_p = sub.add_parser("path")
     p_p.add_argument("--from", dest="from", required=True)
     p_p.add_argument("--to", required=True)
@@ -287,6 +767,8 @@ def main():
             result = cmd_neighbors(conn, args)
         elif args.command == "edges":
             result = cmd_edges(conn, args)
+        elif args.command == "subgraph":
+            result = cmd_subgraph(conn, args)
         elif args.command == "path":
             result = cmd_path(conn, args)
         elif args.command == "facts":

--- a/skills/llm-wiki/scripts/wiki_graph_store.py
+++ b/skills/llm-wiki/scripts/wiki_graph_store.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+wiki_graph_store.py — The compiled graph's SQLite shape, in one place.
+
+Two scripts need this schema: `wiki_graph_extract.py`, which compiles it from
+markdown, and `wiki_graph_query.py`, which rebuilds it from the committed JSONL
+exports when a fresh clone has no database yet. A second copy of the DDL would
+be a divergence waiting to happen — the same failure the shared markdown parser
+was created to end.
+
+Deliberately stdlib-only. `wiki_graph_extract.py` carries a pinned PyYAML and
+runs under `uv`; `wiki_graph_query.py` does neither, and must not start.
+"""
+
+import json
+import sqlite3
+from pathlib import Path
+
+SCHEMA = """
+    CREATE TABLE nodes (
+      id TEXT PRIMARY KEY,
+      slug TEXT NOT NULL UNIQUE,
+      title TEXT NOT NULL,
+      page_type TEXT NOT NULL,
+      node_type TEXT NOT NULL,
+      kind TEXT,
+      path TEXT NOT NULL,
+      created TEXT,
+      updated TEXT,
+      metadata_json TEXT NOT NULL
+    );
+    CREATE TABLE aliases (
+      alias TEXT NOT NULL,
+      node_id TEXT NOT NULL,
+      PRIMARY KEY (alias, node_id),
+      FOREIGN KEY (node_id) REFERENCES nodes(id)
+    );
+    CREATE TABLE edges (
+      id TEXT PRIMARY KEY,
+      subject TEXT NOT NULL,
+      predicate TEXT NOT NULL,
+      object TEXT NOT NULL,
+      source TEXT,
+      evidence TEXT,
+      confidence TEXT,
+      status TEXT,
+      extraction_method TEXT NOT NULL,
+      page TEXT NOT NULL,
+      metadata_json TEXT NOT NULL
+    );
+    CREATE INDEX idx_edges_subject ON edges(subject);
+    CREATE INDEX idx_edges_object ON edges(object);
+    CREATE INDEX idx_edges_predicate ON edges(predicate);
+    CREATE INDEX idx_edges_source ON edges(source);
+"""
+
+NODES_EXPORT = "nodes.jsonl"
+EDGES_EXPORT = "edges.jsonl"
+
+
+def normalize_for_json(value):
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    if isinstance(value, list):
+        return [normalize_for_json(v) for v in value]
+    if isinstance(value, dict):
+        return {k: normalize_for_json(v) for k, v in value.items()}
+    return value
+
+
+def write_sqlite(db_path: Path, nodes: list[dict], aliases: list[dict], edges: list[dict]) -> None:
+    """(Re)create the database at `db_path` from in-memory rows."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    if db_path.exists():
+        db_path.unlink()
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(SCHEMA)
+        for n in sorted(nodes, key=lambda n: n["id"]):
+            metadata_json = json.dumps(normalize_for_json({
+                "tags": n.get("tags", []),
+                "aliases": n.get("aliases", []),
+                "canonical": n.get("canonical", False),
+            }), sort_keys=True, ensure_ascii=False)
+            conn.execute(
+                "INSERT INTO nodes (id, slug, title, page_type, node_type, kind, path, "
+                "created, updated, metadata_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    n["id"], n["slug"], n["title"], n["page_type"], n["node_type"],
+                    n.get("kind") or None, n["path"],
+                    str(n.get("created") or "") or None,
+                    str(n.get("updated") or "") or None,
+                    metadata_json,
+                ),
+            )
+        for a in sorted(aliases, key=lambda a: (a["alias"], a["node_id"])):
+            conn.execute(
+                "INSERT OR IGNORE INTO aliases (alias, node_id) VALUES (?, ?)",
+                (a["alias"], a["node_id"]),
+            )
+        for e in sorted(edges, key=lambda e: e["id"]):
+            metadata_json = json.dumps(normalize_for_json(e.get("extras") or {}),
+                                       sort_keys=True, ensure_ascii=False)
+            conn.execute(
+                "INSERT INTO edges (id, subject, predicate, object, source, evidence, "
+                "confidence, status, extraction_method, page, metadata_json) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    e["id"], e["subject"], e["predicate"], e["object"],
+                    e.get("source") or None, e.get("evidence") or None,
+                    e.get("confidence") or None, e.get("status") or None,
+                    e["extraction_method"], e["page"], metadata_json,
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def export_paths(graph_dir: Path) -> tuple[Path, Path]:
+    return graph_dir / NODES_EXPORT, graph_dir / EDGES_EXPORT
+
+
+def read_exports(graph_dir: Path) -> tuple[list[dict], list[dict], list[dict]]:
+    """Load the committed JSONL exports as (nodes, aliases, edges).
+
+    The aliases table is derived rather than stored: `build_nodes()` fills it
+    from each node's own `aliases` list, so the export already carries every
+    row and a separate file would only be a second thing to keep in sync.
+    """
+    nodes_path, edges_path = export_paths(graph_dir)
+    nodes, edges, aliases = [], [], []
+    for line in nodes_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        node = json.loads(line)
+        nodes.append(node)
+        for alias in node.get("aliases") or []:
+            aliases.append({"alias": str(alias), "node_id": node["id"]})
+    for line in edges_path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            edges.append(json.loads(line))
+    return nodes, aliases, edges

--- a/skills/llm-wiki/scripts/wiki_lint.py
+++ b/skills/llm-wiki/scripts/wiki_lint.py
@@ -45,6 +45,7 @@ CAPITALIZED_PHRASE_RE = re.compile(r"\b([A-Z][a-zA-Z0-9]+(?:\s+[A-Z][a-zA-Z0-9]+
 
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "index.md", "log.md", "README.md"}
 SKIP_TOP_LEVEL_DIRS = wiki_markdown.SKIP_TOP_LEVEL_DIRS
+INDEX_SHARD_LINE_CAP = 300  # SCHEMA.md: split shards that exceed ~300 lines
 
 
 def parse_frontmatter(text: str) -> tuple[dict, str, bool]:
@@ -120,12 +121,14 @@ def parse_date(s):
         return None
 
 
-def lint(pages: list[dict], soft_cap: int, hard_cap: int, required_fm: list[str], suggest_pages: bool, suggest_min: int) -> dict:
+def lint(pages: list[dict], soft_cap: int, hard_cap: int, required_fm: list[str], suggest_pages: bool, suggest_min: int,
+         wiki_root: Path | None = None) -> dict:
     findings = {
         "orphans": [],
         "broken_links": [],
         "oversized_hard": [],
         "oversized_soft": [],
+        "oversized_indexes": [],
         "missing_frontmatter": [],
         "malformed_frontmatter": [],
         "duplicate_slugs": [],
@@ -159,8 +162,9 @@ def lint(pages: list[dict], soft_cap: int, hard_cap: int, required_fm: list[str]
 
     # Orphans, broken links, oversize, frontmatter, staleness
     for p in pages:
-        # Orphans
-        if not inbound.get(p["slug"]):
+        # Orphans. Index/meta pages are navigational roots reached from index.md
+        # (which is excluded as a link source), so they are never true orphans.
+        if not inbound.get(p["slug"]) and p["meta"].get("type") != "index":
             findings["orphans"].append({"slug": p["slug"], "path": p["rel_path"]})
 
         # Broken links
@@ -229,12 +233,37 @@ def lint(pages: list[dict], soft_cap: int, hard_cap: int, required_fm: list[str]
         candidates.sort(key=lambda x: -x["page_count"])
         findings["suggested_pages"] = candidates[:30]
 
+    # Index size check: the routing index is subject to the same scaling cap as
+    # every shard. Otherwise a repository can silently outgrow the very entry
+    # point that is supposed to keep discovery bounded.
+    if wiki_root:
+        index_paths = []
+        root_index = wiki_root / "index.md"
+        if root_index.is_file():
+            index_paths.append(root_index)
+        indexes_dir = wiki_root / "indexes"
+        if indexes_dir.is_dir():
+            index_paths.extend(sorted(indexes_dir.rglob("*.md")))
+        for idx_path in index_paths:
+            try:
+                idx_text = idx_path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            idx_lines = len(idx_text.splitlines())
+            if idx_lines > INDEX_SHARD_LINE_CAP:
+                findings["oversized_indexes"].append({
+                    "path": str(idx_path.relative_to(wiki_root)),
+                    "lines": idx_lines,
+                    "cap": INDEX_SHARD_LINE_CAP,
+                })
+
     findings["summary"] = {
         "total_pages": len(pages),
         "orphans": len(findings["orphans"]),
         "broken_links": len(findings["broken_links"]),
         "oversized_hard": len(findings["oversized_hard"]),
         "oversized_soft": len(findings["oversized_soft"]),
+        "oversized_indexes": len(findings["oversized_indexes"]),
         "missing_frontmatter": len(findings["missing_frontmatter"]),
         "malformed_frontmatter": len(findings["malformed_frontmatter"]),
         "duplicate_slugs": len(findings["duplicate_slugs"]),
@@ -259,6 +288,7 @@ def render_text(findings: dict) -> str:
         ("broken_links", "Broken wikilinks", lambda f: f"  - [[{f['to']}]] referenced from {f['from_path']}"),
         ("oversized_hard", "OVERSIZE (over hard cap — must split)", lambda f: f"  - {f['path']}  ({f['lines']} lines)"),
         ("oversized_soft", "Oversize (over soft cap — consider splitting)", lambda f: f"  - {f['path']}  ({f['lines']} lines)"),
+        ("oversized_indexes", "Index over cap (split or shard by stable sub-category)", lambda f: f"  - {f['path']}  ({f['lines']} lines, cap {f['cap']})"),
         ("missing_frontmatter", "Missing frontmatter fields", lambda f: f"  - {f['path']}  missing: {', '.join(f['missing'])}"),
         ("malformed_frontmatter", "Malformed frontmatter", lambda f: f"  - {f['path']}"),
         ("duplicate_slugs", "Duplicate slugs", lambda f: f"  - {f['slug']}: {', '.join(f['paths'])}"),
@@ -307,12 +337,20 @@ def main():
 
     pages = collect_pages(args.wiki)
     required_fm = [f.strip() for f in args.required_fm.split(",") if f.strip()]
-    findings = lint(pages, args.soft_cap, args.hard_cap, required_fm, args.suggest_pages, args.suggest_min)
+    findings = lint(pages, args.soft_cap, args.hard_cap, required_fm, args.suggest_pages, args.suggest_min,
+                    wiki_root=args.wiki)
 
     if args.json:
         print(json.dumps(findings, indent=2, default=str))
     else:
         print(render_text(findings))
+
+    # A linter that always exits 0 cannot gate anything: a pre-commit hook or a
+    # CI job would have to re-parse the report to learn whether it passed.
+    # Suggestions are advisory and never fail the run.
+    if any(value for key, value in findings.items()
+           if key not in {"summary", "suggested_pages"} and isinstance(value, list)):
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/skills/llm-wiki/scripts/wiki_lint.py
+++ b/skills/llm-wiki/scripts/wiki_lint.py
@@ -33,14 +33,18 @@ from collections import Counter, defaultdict
 from datetime import date, datetime
 from pathlib import Path
 
+import wiki_markdown
+from wiki_markdown import configure_utf8_streams, extract_wikilinks
 
-WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+configure_utf8_streams()
+
+
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 CAPITALIZED_PHRASE_RE = re.compile(r"\b([A-Z][a-zA-Z0-9]+(?:\s+[A-Z][a-zA-Z0-9]+){0,3})\b")
 
 
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "index.md", "log.md", "README.md"}
-SKIP_TOP_LEVEL_DIRS = {"indexes", "graph", "raw"}
+SKIP_TOP_LEVEL_DIRS = wiki_markdown.SKIP_TOP_LEVEL_DIRS
 
 
 def parse_frontmatter(text: str) -> tuple[dict, str, bool]:
@@ -93,7 +97,7 @@ def collect_pages(wiki_root: Path) -> list[dict]:
             continue
         meta, body, malformed = parse_frontmatter(text)
         line_count = text.count("\n") + 1
-        links = [m.group(1).strip() for m in WIKILINK_RE.finditer(body)]
+        links = extract_wikilinks(body)
         pages.append({
             "path": str(md_path),
             "rel_path": str(rel),

--- a/skills/llm-wiki/scripts/wiki_markdown.py
+++ b/skills/llm-wiki/scripts/wiki_markdown.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Shared, dependency-free Markdown helpers for the LLM Wiki tools.
+
+This is deliberately a link extractor, not a renderer. It implements the
+CommonMark block/inline rules that determine whether ``[[...]]`` is literal
+code: fenced and indented code blocks, common container prefixes, raw HTML
+blocks, and backtick code spans scoped to one inline block.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+
+# Top-level directories under the wiki root that hold something other than
+# curated pages, and so are not part of the corpus any tool walks.
+#
+# Shared for the same reason WIKILINK_RE is: five scripts each carried their own
+# copy and they had already diverged — only wiki_search.py knew about
+# `.wiki-cache`. A page that one tool indexes and another ignores is a silent
+# inconsistency, and the failure surfaces far from the cause: an uncurated file
+# dropped into wiki/ gets embedded into the *tracked* vector index by the next
+# hybrid query, while lint and staleness never see it.
+#
+#   indexes/     navigational shards — they describe the wiki, they are not it
+#   graph/       compiled graph artifacts
+#   raw/         unprocessed sources, when a project keeps them inside the wiki
+#   Clippings/   saved web material: scratch input for ingest, not a page
+#   .wiki-cache/ derived retrieval artifacts
+SKIP_TOP_LEVEL_DIRS = frozenset({"indexes", "graph", "raw", "Clippings", ".wiki-cache"})
+
+WIKILINK_RE = re.compile(r"\[\[([^\]|\\\r\n]+)(?:\\?\|[^\]\r\n]+)?\]\]")
+FENCE_OPEN_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})([^\r\n]*)$")
+LIST_MARKER_RE = re.compile(r"^( {0,3})([-+*]|\d{1,9}[.)])(?:([ \t]+)(.*)|)$")
+ATX_HEADING_RE = re.compile(r"^ {0,3}#{1,6}(?:[ \t]+|$)")
+THEMATIC_BREAK_RE = re.compile(r"^ {0,3}(?:\*[ \t]*){3,}$|^ {0,3}(?:-[ \t]*){3,}$|^ {0,3}(?:_[ \t]*){3,}$")
+SETEXT_HEADING_RE = re.compile(r"^ {0,3}(?:=+|-+)[ \t]*$")
+BACKTICK_RUN_RE = re.compile(r"`+")
+HTML_PRE_BLOCK_RE = re.compile(r"^ {0,3}<(pre|script|style|textarea)(?:[ \t>]|$)", re.IGNORECASE)
+HTML_BLOCK_TAGS = (
+    "address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|"
+    "dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|"
+    "frameset|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|"
+    "nav|noframes|ol|optgroup|option|p|param|search|section|summary|table|tbody|td|"
+    "tfoot|th|thead|title|tr|track|ul"
+)
+HTML_BLOCK_TAG_RE = re.compile(
+    rf"^ {{0,3}}</?(?:{HTML_BLOCK_TAGS})(?:[ \t]|/?>|$)",
+    re.IGNORECASE,
+)
+HTML_ATTRIBUTE_NAME = r"[A-Za-z_:][A-Za-z0-9_.:-]*"
+HTML_ATTRIBUTE_VALUE = r'''(?:[^ \t\r\n"'=<>`]+|'[^']*'|"[^"]*")'''
+HTML_ATTRIBUTE = rf"(?:[ \t]+{HTML_ATTRIBUTE_NAME}(?:[ \t]*=[ \t]*{HTML_ATTRIBUTE_VALUE})?)"
+HTML_COMPLETE_TAG_RE = re.compile(
+    rf"^ {{0,3}}(?:"
+    rf"<[A-Za-z][A-Za-z0-9-]*{HTML_ATTRIBUTE}*[ \t]*/?>|"
+    rf"</[A-Za-z][A-Za-z0-9-]*[ \t]*>"
+    rf")[ \t]*$"
+)
+HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+
+def configure_utf8_streams() -> None:
+    """Keep Unicode wiki titles and diagnostics printable on Windows CLIs."""
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8")
+
+
+def _blank_preserving_newlines(text: str) -> str:
+    return "".join(char if char in "\r\n" else " " for char in text)
+
+
+def _is_escaped(text: str, position: int) -> bool:
+    backslashes = 0
+    position -= 1
+    while position >= 0 and text[position] == "\\":
+        backslashes += 1
+        position -= 1
+    return backslashes % 2 == 1
+
+
+def _indent_columns(text: str) -> tuple[int, int]:
+    """Return visual indentation columns and the first non-indent offset."""
+    columns = 0
+    offset = 0
+    while offset < len(text) and text[offset] in " \t":
+        if text[offset] == "\t":
+            columns += 4 - (columns % 4)
+        else:
+            columns += 1
+        offset += 1
+    return columns, offset
+
+
+def _visual_columns(text: str) -> int:
+    """Return the display columns occupied by a container prefix."""
+    columns = 0
+    for character in text:
+        columns += 4 - (columns % 4) if character == "\t" else 1
+    return columns
+
+
+def _strip_columns(text: str, wanted: int) -> tuple[str, bool]:
+    """Strip at least ``wanted`` indentation columns without splitting tabs."""
+    columns = 0
+    offset = 0
+    while offset < len(text) and text[offset] in " \t" and columns < wanted:
+        if text[offset] == "\t":
+            columns += 4 - (columns % 4)
+        else:
+            columns += 1
+        offset += 1
+    return text[offset:], columns >= wanted
+
+
+def _strip_blockquote_prefix(text: str) -> tuple[int, str]:
+    """Strip repeated blockquote markers and return (depth, content)."""
+    depth = 0
+    rest = text
+    while True:
+        match = re.match(r"^ {0,3}>[ \t]?", rest)
+        if not match:
+            return depth, rest
+        depth += 1
+        rest = rest[match.end():]
+
+
+def _list_marker_can_interrupt(marker: re.Match[str], paragraph_active: bool) -> bool:
+    """Apply CommonMark's special rules for a list interrupting a paragraph."""
+    if not paragraph_active:
+        return True
+    item_content = marker.group(4) or ""
+    if not item_content.strip():
+        return False
+    token = marker.group(2)
+    return not token[0].isdigit() or int(token[:-1]) == 1
+
+
+def _list_item(marker: re.Match[str]) -> tuple[int, str]:
+    """Return the continuation indent and content introduced by a list marker."""
+    prefix_without_padding = marker.group(1) + marker.group(2)
+    base_columns = _visual_columns(prefix_without_padding)
+    whitespace = marker.group(3)
+    item_content = marker.group(4) or ""
+    if whitespace is None:  # A marker alone is a valid empty list item.
+        return base_columns + 1, item_content
+
+    full_prefix = marker.group(1) + marker.group(2) + whitespace
+    padding_columns = _visual_columns(full_prefix) - base_columns
+    if padding_columns <= 4:
+        return _visual_columns(full_prefix), item_content
+
+    # CommonMark treats 5+ spaces after a marker as one container padding
+    # space plus indented content.
+    remaining_padding, _ = _strip_columns(whitespace, 1)
+    return base_columns + 1, remaining_padding + item_content
+
+
+def _logical_content(
+    raw: str,
+    containers: list[tuple[str, int]],
+    paragraph_key: tuple[tuple[str, int], ...] | None,
+    allow_new_containers: bool = True,
+) -> tuple[tuple[tuple[str, int], ...], str, bool]:
+    """Return the active container signature and its relative line content.
+
+    Container order is significant: ``- >`` is a list containing a quote,
+    while ``> -`` is a quote containing a list. Keeping the complete stack is
+    also what lets an unclosed fence end exactly when a nested item ends.
+    """
+    if not raw.strip():
+        return tuple(containers), "", False
+
+    content = raw
+    matched = 0
+    for kind, width in containers:
+        if kind == "quote":
+            marker = re.match(r"^ {0,3}>[ \t]?", content)
+            if not marker:
+                break
+            content = content[marker.end():]
+        else:
+            content, belongs = _strip_columns(content, width)
+            if not belongs:
+                break
+        matched += 1
+    if matched != len(containers):
+        del containers[matched:]
+
+    if not allow_new_containers:
+        return tuple(containers), content, False
+
+    starts_list = False
+    while True:
+        quote = re.match(r"^ {0,3}>[ \t]?", content)
+        if quote:
+            containers.append(("quote", 0))
+            content = content[quote.end():]
+            continue
+
+        list_marker = LIST_MARKER_RE.match(content)
+        paragraph_active = paragraph_key == tuple(containers)
+        if (list_marker
+                and not THEMATIC_BREAK_RE.match(content)
+                and _list_marker_can_interrupt(list_marker, paragraph_active)):
+            indent, content = _list_item(list_marker)
+            containers.append(("list", indent))
+            starts_list = True
+            continue
+        break
+
+    return tuple(containers), content, starts_list
+
+
+def _html_block_opener(content: str, paragraph_active: bool) -> tuple[str, bool] | None:
+    """Return (termination mode, already closed) for a CommonMark HTML block."""
+    if re.match(r"^ {0,3}<!--", content):
+        return "comment", "-->" in content
+    if re.match(r"^ {0,3}<\?", content):
+        return "processing", "?>" in content
+    if re.match(r"^ {0,3}<![A-Z]", content):
+        return "declaration", ">" in content
+    if re.match(r"^ {0,3}<!\[CDATA\[", content):
+        return "cdata", "]]>" in content
+
+    pre_match = HTML_PRE_BLOCK_RE.match(content)
+    if pre_match:
+        tag = pre_match.group(1).lower()
+        return f"tag:{tag}", bool(re.search(rf"</{tag}[ \t]*>", content, re.IGNORECASE))
+    if HTML_BLOCK_TAG_RE.match(content):
+        return "blank", False
+    if not paragraph_active and HTML_COMPLETE_TAG_RE.match(content):
+        return "blank", False
+    return None
+
+
+def _html_block_closed(mode: str, content: str) -> bool:
+    if mode == "comment":
+        return "-->" in content
+    if mode == "processing":
+        return "?>" in content
+    if mode == "declaration":
+        return ">" in content
+    if mode == "cdata":
+        return "]]>" in content
+    if mode.startswith("tag:"):
+        tag = mode.partition(":")[2]
+        return bool(re.search(rf"</{tag}[ \t]*>", content, re.IGNORECASE))
+    return False
+
+
+def strip_block_code(text: str) -> str:
+    """Mask fenced, indented, and raw HTML blocks.
+
+    Fences are container-aware for blockquotes and ordinary list items. An
+    unclosed fence ends at the end of its container (or the document at root).
+    """
+    output: list[str] = []
+    lines = text.splitlines(keepends=True)
+    containers: list[tuple[str, int]] = []
+    fence: tuple[str, int, tuple[tuple[str, int], ...]] | None = None
+    indented: tuple[tuple[str, int], ...] | None = None
+    html_block: tuple[str, tuple[tuple[str, int], ...]] | None = None
+    paragraph_key: tuple[tuple[str, int], ...] | None = None
+
+    for line in lines:
+        ending_length = len(line) - len(line.rstrip("\r\n"))
+        raw = line[:-ending_length] if ending_length else line
+        literal_block_active = fence is not None or html_block is not None
+        key, content, starts_list = _logical_content(
+            raw,
+            containers,
+            paragraph_key,
+            allow_new_containers=not literal_block_active,
+        )
+
+        if fence is not None:
+            fence_char, fence_length, fence_key = fence
+            if key != fence_key and content.strip():
+                fence = None
+                key, content, starts_list = _logical_content(raw, containers, paragraph_key)
+            else:
+                closing = re.fullmatch(
+                    rf" {{0,3}}{re.escape(fence_char)}{{{fence_length},}}[ \t]*",
+                    content,
+                )
+                output.append(_blank_preserving_newlines(line))
+                if closing:
+                    fence = None
+                continue
+
+        if indented is not None:
+            if key == indented and (not content.strip() or _indent_columns(content)[0] >= 4):
+                output.append(_blank_preserving_newlines(line))
+                continue
+            indented = None
+
+        if html_block is not None:
+            mode, html_key = html_block
+            if mode == "blank" and not content.strip():
+                html_block = None
+                output.append(line)
+                paragraph_key = None
+                continue
+            if key != html_key and content.strip():
+                html_block = None
+                key, content, starts_list = _logical_content(raw, containers, paragraph_key)
+            else:
+                output.append(_blank_preserving_newlines(line))
+                if _html_block_closed(mode, content):
+                    html_block = None
+                continue
+
+        if not content.strip():
+            output.append(line)
+            paragraph_key = None
+            continue
+
+        fence_match = FENCE_OPEN_RE.match(content)
+        if fence_match:
+            opening = fence_match.group(1)
+            info = fence_match.group(2)
+            if opening[0] != "`" or "`" not in info:
+                fence = (opening[0], len(opening), key)
+                output.append(_blank_preserving_newlines(line))
+                paragraph_key = None
+                continue
+
+        html_open = _html_block_opener(content, paragraph_key == key)
+        if html_open:
+            mode, already_closed = html_open
+            output.append(_blank_preserving_newlines(line))
+            if mode == "blank" or not already_closed:
+                html_block = (mode, key)
+            paragraph_key = None
+            continue
+
+        indent, _ = _indent_columns(content)
+        if indent >= 4 and paragraph_key != key:
+            indented = key
+            output.append(_blank_preserving_newlines(line))
+            continue
+
+        output.append(line)
+        if (starts_list or ATX_HEADING_RE.match(content)
+                or THEMATIC_BREAK_RE.match(content) or SETEXT_HEADING_RE.match(content)):
+            paragraph_key = None if (ATX_HEADING_RE.match(content)
+                                     or THEMATIC_BREAK_RE.match(content)
+                                     or SETEXT_HEADING_RE.match(content)) else key
+        else:
+            paragraph_key = key
+
+    return "".join(output)
+
+
+def _strip_inline_code_block(text: str) -> str:
+    runs = list(BACKTICK_RUN_RE.finditer(text))
+    spans: list[tuple[int, int]] = []
+    index = 0
+    while index < len(runs):
+        opener = runs[index]
+        if _is_escaped(text, opener.start()):
+            index += 1
+            continue
+        for closer_index in range(index + 1, len(runs)):
+            closer = runs[closer_index]
+            if len(closer.group(0)) == len(opener.group(0)):
+                spans.append((opener.start(), closer.end()))
+                index = closer_index + 1
+                break
+        else:
+            index += 1
+
+    if not spans:
+        return text
+    output: list[str] = []
+    cursor = 0
+    for start, end in spans:
+        output.append(text[cursor:start])
+        output.append(_blank_preserving_newlines(text[start:end]))
+        cursor = end
+    output.append(text[cursor:])
+    return "".join(output)
+
+
+def strip_inline_code(text: str) -> str:
+    """Mask code spans without matching delimiters across block boundaries."""
+    output: list[str] = []
+    block: list[str] = []
+    block_key: tuple[int, bool] | None = None
+
+    def flush() -> None:
+        if block:
+            output.append(_strip_inline_code_block("".join(block)))
+            block.clear()
+
+    for line in text.splitlines(keepends=True):
+        ending_length = len(line) - len(line.rstrip("\r\n"))
+        raw = line[:-ending_length] if ending_length else line
+        if not raw.strip():
+            flush()
+            output.append(line)
+            block_key = None
+            continue
+
+        quote_depth, content = _strip_blockquote_prefix(raw)
+        list_marker = LIST_MARKER_RE.match(content)
+        starts_list = bool(
+            list_marker
+            and not THEMATIC_BREAK_RE.match(content)
+            and _list_marker_can_interrupt(list_marker, bool(block))
+        )
+        is_setext = bool(SETEXT_HEADING_RE.match(content))
+        is_new_block = bool(
+            ATX_HEADING_RE.match(content)
+            or THEMATIC_BREAK_RE.match(content)
+            or is_setext
+            or starts_list
+        )
+        key = (quote_depth, is_new_block)
+        if block and (quote_depth != block_key[0] or is_new_block):
+            flush()
+        block.append(line)
+        block_key = key
+        if ATX_HEADING_RE.match(content) or THEMATIC_BREAK_RE.match(content) or is_setext:
+            flush()
+            block_key = None
+    flush()
+    return "".join(output)
+
+
+def extract_wikilinks(body: str) -> list[str]:
+    """Return cross-page wikilink targets outside Markdown code constructs."""
+    stripped = strip_block_code(body)
+    stripped = HTML_COMMENT_RE.sub(
+        lambda match: _blank_preserving_newlines(match.group(0)),
+        stripped,
+    )
+    stripped = strip_inline_code(stripped)
+    links: list[str] = []
+    for match in WIKILINK_RE.finditer(stripped):
+        if _is_escaped(stripped, match.start()):
+            continue
+        target = match.group(1).strip()
+        if target.startswith("#"):
+            continue
+        target = target.split("#", 1)[0].strip()
+        if target:
+            links.append(target)
+    return links

--- a/skills/llm-wiki/scripts/wiki_search.py
+++ b/skills/llm-wiki/scripts/wiki_search.py
@@ -48,8 +48,12 @@ from collections import Counter, defaultdict
 from datetime import date, datetime
 from pathlib import Path
 
+from wiki_markdown import (SKIP_TOP_LEVEL_DIRS, configure_utf8_streams,
+                           extract_wikilinks)
 
-WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+configure_utf8_streams()
+
+
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 TOKEN_RE = re.compile(r"[a-z0-9]+")
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
@@ -96,10 +100,6 @@ def tokenize(text: str) -> list[str]:
 
 def slug_from_path(path: Path, wiki_root: Path) -> str:
     return path.stem
-
-
-def extract_wikilinks(body: str) -> list[str]:
-    return [m.group(1).strip() for m in WIKILINK_RE.finditer(body)]
 
 
 def cache_page_body(sections: list[dict]) -> str:
@@ -174,7 +174,7 @@ def collect_pages(wiki_root: Path, cache_path: Path | None = None) -> list[dict]
         rel = md_path.relative_to(wiki_root)
         if rel.parts[0] in {"SCHEMA.md", "index.md", "log.md"} or rel.name.startswith("."):
             continue
-        if rel.parts[0] in {"indexes", "graph", "raw", ".wiki-cache"}:
+        if rel.parts[0] in SKIP_TOP_LEVEL_DIRS:
             continue
         rel_path = str(rel)
         try:

--- a/skills/llm-wiki/scripts/wiki_search.py
+++ b/skills/llm-wiki/scripts/wiki_search.py
@@ -131,22 +131,30 @@ def cache_page_body(sections: list[dict]) -> str:
     return "\n".join(chunks)
 
 
-def load_parse_cache(cache_path: Path) -> dict:
+def load_parse_cache(cache_path: Path) -> dict | None:
+    """Return the cached file map, or None when the cache is unusable.
+
+    None and `{}` are different answers, and conflating them broke `/wiki:init`:
+    a wiki with no ingested pages yet has a perfectly valid cache whose file map
+    is empty. A caller that treats emptiness as corruption rejects the one state
+    every new wiki starts in. Searching only needs "is there anything to reuse",
+    so it collapses both to `{}`; setup needs the distinction.
+    """
     try:
         payload = json.loads(cache_path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         print("cache: rebuilding (missing)", file=sys.stderr)
-        return {}
+        return None
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         print(f"cache: rebuilding ({exc})", file=sys.stderr)
-        return {}
+        return None
     if not isinstance(payload, dict) or payload.get("schema") != PARSE_CACHE_SCHEMA:
-        print(f"cache: rebuilding (schema is not {PARSE_CACHE_SCHEMA})", file=sys.stderr)
-        return {}
+        print("cache: rebuilding (schema is not {})".format(PARSE_CACHE_SCHEMA), file=sys.stderr)
+        return None
     files = payload.get("files")
     if not isinstance(files, dict):
         print("cache: rebuilding (invalid files)", file=sys.stderr)
-        return {}
+        return None
     for rel_path, entry in files.items():
         sections = entry.get("sections") if isinstance(entry, dict) else None
         valid_sections = (
@@ -170,7 +178,7 @@ def load_parse_cache(cache_path: Path) -> dict:
             and valid_sections
         ):
             print(f"cache: rebuilding (invalid entry: {rel_path})", file=sys.stderr)
-            return {}
+            return None
     return files
 
 
@@ -214,7 +222,9 @@ def write_parse_cache(cache_path: Path, files: dict) -> None:
 def collect_pages(wiki_root: Path, cache_path: Path | None = None) -> list[dict]:
     """Walk the wiki and return [{path, slug, meta, body, tokens, links}]."""
     pages = []
-    cached_files = load_parse_cache(cache_path) if cache_path else {}
+    # A search does not care why there is nothing to reuse -- missing, stale and
+    # corrupt all mean "parse from source".
+    cached_files = (load_parse_cache(cache_path) or {}) if cache_path else {}
     next_cache = {}
     for md_path in wiki_root.rglob("*.md"):
         rel = md_path.relative_to(wiki_root)

--- a/skills/llm-wiki/scripts/wiki_search.py
+++ b/skills/llm-wiki/scripts/wiki_search.py
@@ -49,7 +49,7 @@ from datetime import date, datetime
 from pathlib import Path
 
 from wiki_markdown import (SKIP_TOP_LEVEL_DIRS, configure_utf8_streams,
-                           extract_wikilinks)
+                           extract_wikilinks, strip_block_code)
 
 configure_utf8_streams()
 
@@ -62,9 +62,19 @@ TOKEN_RE = re.compile(r"[a-z0-9]+")
 # serving entries built by the previous parser: `--cache` and a cold run
 # disagree, and the vector index syncs against stale locators and text.
 # Schema history: 1 = the original format. 2 = POSIX cache keys and
-# newline-normalized content hashes.
-PARSE_CACHE_SCHEMA = 2
-HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
+# newline-normalized content hashes. 3 = CommonMark-aware code masking,
+# three-space ATX indent allowance, literal trailing hashes kept in heading
+# text, empty ATX headings recognized, sections carrying nothing dropped.
+PARSE_CACHE_SCHEMA = 3
+# CommonMark ATX heading: up to three leading spaces, one to six hashes, then
+# either end of line (an empty heading) or a space/tab before the content.
+HEADING_RE = re.compile(r"^ {0,3}(#{1,6})(?:[ \t]+(.*?))?[ \t]*$")
+# The optional closing sequence is only a closing sequence when whitespace
+# precedes it, or when it is the whole content. Stripping any trailing hash run
+# instead renames `## C#` to `C` and `## F##` to `F`, silently corrupting the
+# heading path, the searchable text, the JSON evidence and the embedded vector
+# for every heading that legitimately ends in a hash.
+CLOSING_HASHES_RE = re.compile(r"(?:^|[ \t]+)#+[ \t]*$")
 LOCAL_EMBED_MODEL = "BAAI/bge-small-en-v1.5"
 VECTOR_INDEX_SCHEMA = "2"
 VECTOR_INDEX_NAME = "embeddings.sqlite"
@@ -250,41 +260,64 @@ def collect_pages(wiki_root: Path, cache_path: Path | None = None) -> list[dict]
 
 
 def split_sections(title: str, body: str) -> list[dict]:
-    """Split a page body into sections at ATX headings outside code fences."""
+    """Split a page body into sections at ATX headings outside code blocks.
+
+    Heading detection runs against `strip_block_code`, the same CommonMark state
+    machine the wikilink extractor uses, rather than a local fence toggle. A
+    naive toggle gets four documented cases wrong — `~~~` "closing" a backtick
+    fence, three backticks "closing" a fence of four, a closing fence with
+    trailing text, and indented code — and each mistake invents a heading inside
+    a code block, which then becomes a BM25 unit, a section locator and an
+    embedded vector. Sections keep the original lines; only the heading test
+    looks at the masked copy.
+    """
     del title  # Kept in the API for parity with the TypeScript implementation.
     sections = []
     heading_stack: list[tuple[int, str]] = []
     current_path: list[str] = []
     current_level = 0
+    current_name = ""
     current_lines: list[str] = []
-    in_fence = False
 
     def append_section() -> None:
+        text = "\n".join(current_lines)
+        # Drop a section that neither names itself nor holds text: the empty
+        # preamble of a page that opens with a heading, and the empty ATX
+        # heading with nothing under it. Either carries no evidence, yet both
+        # are scored, embedded, and consume a --per-page slot a real passage
+        # needs. An inherited path does not count as a name — only the
+        # section's own heading does.
+        if not current_name and not text.strip():
+            return
         sections.append({
             "heading_path": current_path.copy(),
             "level": current_level,
-            "text": "\n".join(current_lines),
+            "text": text,
             "section_index": len(sections),
         })
 
-    for line in body.splitlines():
-        stripped = line.strip()
-        if stripped.startswith(("```", "~~~")):
-            in_fence = not in_fence
-            current_lines.append(line)
-            continue
-        heading = None if in_fence else HEADING_RE.match(line)
+    body_lines = body.splitlines()
+    # Code lines come back blanked, newline-for-newline, so they can never match
+    # the heading pattern.
+    masked_lines = strip_block_code(body).splitlines()
+    for index, line in enumerate(body_lines):
+        masked = masked_lines[index] if index < len(masked_lines) else ""
+        heading = HEADING_RE.match(masked)
         if not heading:
             current_lines.append(line)
             continue
 
         append_section()
         current_level = len(heading.group(1))
-        heading_text = heading.group(2).strip()
+        current_name = CLOSING_HASHES_RE.sub("", heading.group(2) or "").strip()
         while heading_stack and heading_stack[-1][0] >= current_level:
             heading_stack.pop()
-        heading_stack.append((current_level, heading_text))
-        current_path = [text for _, text in heading_stack]
+        # An empty ATX heading (`###` alone) is a real section boundary, so it
+        # takes its place on the stack and keeps nesting correct — but it
+        # contributes no name, so it is left out of the visible path rather than
+        # padding it with an empty string.
+        heading_stack.append((current_level, current_name))
+        current_path = [text for _, text in heading_stack if text]
         current_lines = []
 
     append_section()

--- a/skills/llm-wiki/scripts/wiki_search.py
+++ b/skills/llm-wiki/scripts/wiki_search.py
@@ -693,18 +693,49 @@ def json_result(
     }
 
 
-def emit_json(args, results: list[dict], mode: str = "lexical") -> None:
+def emit_json(args, results: list[dict], mode: str = "lexical", error: str | None = None) -> None:
+    """Emit the structured envelope.
+
+    `--json` is a contract: a caller that asked for structured output gets a
+    parseable envelope on every path, including the failure paths. Returning
+    nothing on stdout — as an untokenizable query used to — silently breaks
+    every scripted consumer.
+    """
     print(json.dumps({
         "query": args.query,
         "wiki": str(args.wiki),
         "granularity": args.granularity,
         "mode": mode,
         "results": results,
+        "error": error,
     }, ensure_ascii=False))
 
 
-def emit_empty_json(args, mode: str = "lexical") -> None:
-    emit_json(args, [], mode)
+def emit_empty_json(args, mode: str = "lexical", error: str | None = None) -> None:
+    emit_json(args, [], mode, error)
+
+
+def fail(args, message: str, code: int = 2) -> None:
+    """Report an unusable request: JSON envelope when asked, stderr otherwise."""
+    if getattr(args, "json", False):
+        emit_empty_json(args, error=message)
+    else:
+        print(message, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def require_positive(args, flag: str, value: int | None) -> None:
+    """Reject non-positive counts before they turn into silent nonsense.
+
+    Raw `type=int` let every count flag through, and each one failed
+    differently: `--top 0` returned one section but zero pages, a negative
+    `--top-linked` became a negative list slice, and `--per-page 0` silently
+    dropped every result. Validating after parsing rather than in `type=`
+    keeps the `--json` contract — argparse's own error path writes usage text
+    to stderr, which no structured consumer can read.
+    """
+    if value is not None and value < 1:
+        fail(args, f"{flag} must be a positive integer, got {value}")
 
 
 def cmd_search(args, pages: list[dict]) -> None:
@@ -717,8 +748,11 @@ def cmd_search(args, pages: list[dict]) -> None:
         return
     query_tokens = tokenize(args.query)
     if not query_tokens:
-        print("Empty query.", file=sys.stderr)
-        return
+        # The tokenizer keeps [a-z0-9]+ only, so a query written entirely in a
+        # non-Latin script yields nothing to match. Say so instead of returning
+        # an empty result set that looks like "searched, found nothing".
+        fail(args, "Query has no searchable tokens: the lexical tokenizer keeps "
+                   "[a-z0-9]+ only, so non-Latin scripts must be normalized first.")
 
     if args.granularity == "page":
         idx = build_bm25(filtered)
@@ -892,17 +926,22 @@ def main():
     parser.add_argument("--json", action="store_true", help="Emit structured JSON search results.")
     parser.add_argument("--no-embed", action="store_true", help="Force lexical-only search.")
     args = parser.parse_args()
+    require_positive(args, "--top", args.top)
+    require_positive(args, "--top-linked", args.top_linked)
+    require_positive(args, "--per-page", args.per_page)
     cache_path = None
     if args.cache:
         cache_path = args.wiki / ".wiki-cache" / "search-index.json" if args.cache == "AUTO" else Path(args.cache)
 
     if not args.wiki.exists():
-        print(f"Wiki directory not found: {args.wiki}", file=sys.stderr)
-        sys.exit(1)
+        fail(args, f"Wiki directory not found: {args.wiki}", code=1)
 
     pages = collect_pages(args.wiki, cache_path)
     if not pages:
-        print(f"No wiki pages found under {args.wiki}", file=sys.stderr)
+        if args.json:
+            emit_empty_json(args, error=f"No wiki pages found under {args.wiki}")
+        else:
+            print(f"No wiki pages found under {args.wiki}", file=sys.stderr)
         sys.exit(0)
 
     if args.backlinks:
@@ -911,6 +950,8 @@ def main():
         cmd_top_linked(args, pages)
     elif args.query:
         cmd_search(args, pages)
+    elif args.json:
+        fail(args, "No query given. Pass a query, --backlinks <slug>, or --top-linked N.")
     else:
         parser.print_help()
         sys.exit(1)

--- a/skills/llm-wiki/scripts/wiki_search.py
+++ b/skills/llm-wiki/scripts/wiki_search.py
@@ -56,6 +56,14 @@ configure_utf8_streams()
 
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 TOKEN_RE = re.compile(r"[a-z0-9]+")
+# Bump whenever the cached representation of a page changes -- how a page is
+# keyed, how it is hashed, or the fields stored per section. The cache keys
+# entries by file hash alone, so without a bump an unchanged page keeps
+# serving entries built by the previous parser: `--cache` and a cold run
+# disagree, and the vector index syncs against stale locators and text.
+# Schema history: 1 = the original format. 2 = POSIX cache keys and
+# newline-normalized content hashes.
+PARSE_CACHE_SCHEMA = 2
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
 LOCAL_EMBED_MODEL = "BAAI/bge-small-en-v1.5"
 VECTOR_INDEX_SCHEMA = "2"
@@ -121,8 +129,8 @@ def load_parse_cache(cache_path: Path) -> dict:
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         print(f"cache: rebuilding ({exc})", file=sys.stderr)
         return {}
-    if not isinstance(payload, dict) or payload.get("schema") != 1:
-        print("cache: rebuilding (unsupported schema)", file=sys.stderr)
+    if not isinstance(payload, dict) or payload.get("schema") != PARSE_CACHE_SCHEMA:
+        print(f"cache: rebuilding (schema is not {PARSE_CACHE_SCHEMA})", file=sys.stderr)
         return {}
     files = payload.get("files")
     if not isinstance(files, dict):
@@ -159,7 +167,8 @@ def write_parse_cache(cache_path: Path, files: dict) -> None:
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     temporary = Path(str(cache_path) + ".tmp")
     temporary.write_text(
-        json.dumps({"schema": 1, "files": files}, ensure_ascii=False, sort_keys=True),
+        json.dumps({"schema": PARSE_CACHE_SCHEMA, "files": files},
+                   ensure_ascii=False, sort_keys=True),
         encoding="utf-8",
     )
     os.replace(temporary, cache_path)
@@ -176,12 +185,27 @@ def collect_pages(wiki_root: Path, cache_path: Path | None = None) -> list[dict]
             continue
         if rel.parts[0] in SKIP_TOP_LEVEL_DIRS:
             continue
-        rel_path = str(rel)
+        # POSIX form, always: rel_path is the cache key, the JSON field and half
+        # of the vector-index locator. Using the native separator makes a built
+        # embeddings.sqlite unusable on any other OS -- every section looks new
+        # and triggers a full re-embed after a fresh clone.
+        rel_path = rel.as_posix()
         try:
             raw = md_path.read_bytes()
         except OSError:
             continue
-        digest = hashlib.sha256(raw).hexdigest()
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        # Normalize line endings before hashing or parsing. Two reasons, both
+        # about identity: the cache reconstructs bodies by joining on "\n", so a
+        # CRLF file would read back differently than it was parsed; and the
+        # digest feeds the section content hash, so a CRLF checkout and an LF
+        # checkout of the same commit would disagree about every section and
+        # re-embed the whole corpus.
+        text = text.replace("\r\n", "\n").replace("\r", "\n")
+        digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
         cached = cached_files.get(rel_path)
         if cached and cached.get("sha256") == digest:
             meta = cached.get("meta", {})
@@ -189,10 +213,6 @@ def collect_pages(wiki_root: Path, cache_path: Path | None = None) -> list[dict]
             sections = cached.get("sections", [])
             body = cache_page_body(sections)
         else:
-            try:
-                text = raw.decode("utf-8")
-            except UnicodeDecodeError:
-                continue
             meta, body = parse_frontmatter(text)
             links = extract_wikilinks(body)
             title = meta.get("title") or slug_from_path(md_path, wiki_root)

--- a/skills/llm-wiki/scripts/wiki_search.py
+++ b/skills/llm-wiki/scripts/wiki_search.py
@@ -44,6 +44,7 @@ import os
 import re
 import sqlite3
 import sys
+import tempfile
 from collections import Counter, defaultdict
 from datetime import date, datetime
 from pathlib import Path
@@ -174,14 +175,40 @@ def load_parse_cache(cache_path: Path) -> dict:
 
 
 def write_parse_cache(cache_path: Path, files: dict) -> None:
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = Path(str(cache_path) + ".tmp")
-    temporary.write_text(
-        json.dumps({"schema": PARSE_CACHE_SCHEMA, "files": files},
-                   ensure_ascii=False, sort_keys=True),
-        encoding="utf-8",
-    )
-    os.replace(temporary, cache_path)
+    """Persist the parse cache, tolerating concurrent writers.
+
+    Two agents (or a search and a benchmark) routinely share one wiki. A fixed
+    `<cache>.tmp` name made them collide: one process writes the scratch file
+    while another renames it, which on Windows raises PermissionError from
+    either the write or the rename — measured at 4-8 failures per 12 concurrent
+    queries. Each writer now gets its own scratch file in the destination
+    directory, so the only remaining contention is the atomic rename.
+
+    Persisting is also best-effort by nature: the cache only saves reparsing
+    work, and the results are already computed by the time it is written. A
+    losing racer therefore warns and returns rather than failing a query that
+    otherwise succeeded.
+    """
+    payload = json.dumps({"schema": PARSE_CACHE_SCHEMA, "files": files},
+                         ensure_ascii=False, sort_keys=True)
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        handle, temporary = tempfile.mkstemp(
+            dir=cache_path.parent, prefix=cache_path.name + ".", suffix=".tmp"
+        )
+    except OSError as exc:
+        print(f"cache: not written ({exc})", file=sys.stderr)
+        return
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as stream:
+            stream.write(payload)
+        os.replace(temporary, cache_path)
+    except OSError as exc:
+        print(f"cache: not written ({exc})", file=sys.stderr)
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
 
 
 def collect_pages(wiki_root: Path, cache_path: Path | None = None) -> list[dict]:

--- a/skills/llm-wiki/scripts/wiki_search.py
+++ b/skills/llm-wiki/scripts/wiki_search.py
@@ -748,6 +748,83 @@ def require_positive(args, flag: str, value: int | None) -> None:
         fail(args, f"{flag} must be a positive integer, got {value}")
 
 
+def primary_provenance(page: dict) -> str:
+    """Return a stable key for source/concept variants derived from the same source."""
+    meta = page["meta"]
+    doc_path = meta.get("doc_path")
+    if isinstance(doc_path, str) and doc_path:
+        return doc_path.lower().replace("\\", "/")
+    sources = meta.get("sources", []) or []
+    if isinstance(sources, str):
+        sources = [sources]
+    if sources:
+        return str(sources[0]).lower().replace("\\", "/")
+    return f"page:{page['slug']}"
+
+
+def collapse_by_provenance(scored_pages: list[tuple[float, dict]], prefer_type: str | None) -> list[tuple[float, dict]]:
+    """Remove duplicate source pages without collapsing distinct derived pages.
+
+    Multiple concept/synthesis pages may legitimately derive from the same primary
+    source, so each remains searchable. A source page is retained only when its
+    provenance group has no derived page. When a source page is hidden, only
+    that removed source's score may be transferred to one derived
+    representative. ``prefer_type`` selects that representative when possible;
+    the other distinct derived pages retain their own scores.
+    """
+    groups = defaultdict(list)
+    for score, page in scored_pages:
+        groups[primary_provenance(page)].append((score, page))
+
+    collapsed: list[tuple[float, dict]] = []
+    for candidates in groups.values():
+        derived = [item for item in candidates if item[1]["meta"].get("type") != "source"]
+        if derived:
+            representative = max(derived, key=lambda item: (
+                bool(prefer_type and item[1]["meta"].get("type") == prefer_type),
+                item[0],
+                item[1]["slug"],
+            ))
+            source_scores = [
+                score for score, page in candidates
+                if page["meta"].get("type") == "source"
+            ]
+            transferred_score = max(source_scores) if source_scores else None
+            for score, page in derived:
+                if page is representative[1] and transferred_score is not None:
+                    score = max(score, transferred_score)
+                collapsed.append((score, page))
+        else:
+            collapsed.append(max(candidates, key=lambda item: item[0]))
+    collapsed.sort(key=lambda item: (
+        -item[0],
+        0 if prefer_type and item[1]["meta"].get("type") == prefer_type else 1,
+        item[1]["slug"],
+    ))
+    return collapsed
+
+
+def suppressed_source_pages(matched_pages: list[dict]) -> set[str]:
+    """Return rel_paths of source pages hidden by a derived page of the same provenance.
+
+    Section granularity ranks sections, not pages, so the page-level score
+    transfer in ``collapse_by_provenance`` has no meaning here: the RRF score of
+    a section is not transferable to a different page's section. What carries
+    over is the rule itself — a `source` page is only worth showing when nothing
+    derived from that same primary source matched.
+    """
+    by_provenance = defaultdict(list)
+    for page in matched_pages:
+        by_provenance[primary_provenance(page)].append(page)
+    suppressed = set()
+    for group in by_provenance.values():
+        if any(page["meta"].get("type") != "source" for page in group):
+            suppressed.update(
+                page["rel_path"] for page in group if page["meta"].get("type") == "source"
+            )
+    return suppressed
+
+
 def cmd_search(args, pages: list[dict]) -> None:
     filtered = [page for page in pages if passes_filters(page, args)]
     if not filtered:
@@ -766,9 +843,12 @@ def cmd_search(args, pages: list[dict]) -> None:
 
     if args.granularity == "page":
         idx = build_bm25(filtered)
-        scored = [(bm25_score(query_tokens, i, idx), i) for i in range(len(filtered))]
+        scored = [(bm25_score(query_tokens, i, idx), filtered[i]) for i in range(len(filtered))]
+        scored = [(score, page) for score, page in scored if score > 0]
         scored.sort(key=lambda item: -item[0])
-        top = [(score, filtered[i]) for score, i in scored[:args.top] if score > 0]
+        if args.dedup_provenance:
+            scored = collapse_by_provenance(scored, args.prefer_type)
+        top = scored[:args.top]
         if not top:
             if args.json:
                 emit_empty_json(args)
@@ -842,11 +922,26 @@ def cmd_search(args, pages: list[dict]) -> None:
                 file=sys.stderr,
             )
 
+    suppressed = set()
+    if args.dedup_provenance:
+        matched = {}
+        for _score, section_index, _retrievers in ranked:
+            page = sections[section_index]["page"]
+            matched.setdefault(page["rel_path"], page)
+        suppressed = suppressed_source_pages(list(matched.values()))
+        if args.prefer_type:
+            ranked.sort(key=lambda item: (
+                -item[0],
+                0 if sections[item[1]]["page"]["meta"].get("type") == args.prefer_type else 1,
+            ))
+
     page_counts = Counter()
     top_sections = []
     for score, section_index, retrievers in ranked:
         section = sections[section_index]
         rel_path = section["page"]["rel_path"]
+        if rel_path in suppressed:
+            continue
         if page_counts[rel_path] >= args.per_page:
             continue
         page_counts[rel_path] += 1
@@ -923,6 +1018,10 @@ def main():
     parser.add_argument("--wiki", type=Path, default=Path("wiki"), help="Wiki directory (default: ./wiki).")
     parser.add_argument("--top", type=int, default=10, help="Top N results (default: 10).")
     parser.add_argument("--type", help="Filter by frontmatter type.")
+    parser.add_argument("--dedup-provenance", action="store_true",
+                        help="Hide duplicate source pages without collapsing derived concepts.")
+    parser.add_argument("--prefer-type",
+                        help="Prefer this page type as the representative of a provenance group.")
     parser.add_argument("--tag", action="append", default=[], help="Filter by tag (repeatable).")
     parser.add_argument("--since", help="Only pages updated on or after YYYY-MM-DD.")
     parser.add_argument("--backlinks", help="Find pages linking to this slug.")

--- a/skills/llm-wiki/scripts/wiki_search.py
+++ b/skills/llm-wiki/scripts/wiki_search.py
@@ -76,6 +76,13 @@ HEADING_RE = re.compile(r"^ {0,3}(#{1,6})(?:[ \t]+(.*?))?[ \t]*$")
 # heading path, the searchable text, the JSON evidence and the embedded vector
 # for every heading that legitimately ends in a hash.
 CLOSING_HASHES_RE = re.compile(r"(?:^|[ \t]+)#+[ \t]*$")
+# Reciprocal-rank fusion constant, and how many hits each channel
+# contributes. Named because --debug-ranking reports them: a diagnostic
+# that prints numbers the caller cannot tie back to the parameters that
+# produced them is a riddle.
+RRF_K = 60
+LEXICAL_CANDIDATE_LIMIT = 50
+SEMANTIC_CANDIDATE_LIMIT = 50
 LOCAL_EMBED_MODEL = "BAAI/bge-small-en-v1.5"
 VECTOR_INDEX_SCHEMA = "2"
 VECTOR_INDEX_NAME = "embeddings.sqlite"
@@ -610,7 +617,13 @@ def local_semantic_order(
     all_sections: list[dict],
     allowed_locators: set[str],
     wiki_root: Path,
-) -> list[str]:
+) -> list[tuple[str, float]]:
+    """Return [(locator, cosine_distance)] best-first.
+
+    The distance rides along because it is the only place it exists: it is not
+    stored, not recomputable without the model, and `--debug-ranking` has to
+    show it to explain why a section did or did not clear the threshold.
+    """
     model, sqlite_vec, dimension = load_local_embedding_backend()
     connection = open_vector_index(wiki_root, sqlite_vec, dimension)
     try:
@@ -623,10 +636,10 @@ def local_semantic_order(
         if not allowed_ids:
             return []
         query_blob = sqlite_vec.serialize_float32(embed_query(model, query))
-        limit = min(50, len(allowed_ids))
+        limit = min(SEMANTIC_CANDIDATE_LIMIT, len(allowed_ids))
         if len(allowed_ids) == len(locator_ids):
             ranked_ids = [
-                row_id
+                (row_id, distance)
                 for row_id, distance in connection.execute(
                     "SELECT rowid, distance FROM semantic_vectors "
                     "WHERE embedding MATCH ? AND k = ? ORDER BY distance",
@@ -643,7 +656,7 @@ def local_semantic_order(
                 ((row_id,) for row_id in allowed_ids),
             )
             ranked_ids = [
-                row_id
+                (row_id, distance)
                 for row_id, distance in connection.execute(
                     "SELECT vectors.rowid, "
                     "vec_distance_cosine(vectors.embedding, ?) AS distance "
@@ -655,7 +668,7 @@ def local_semantic_order(
                 if distance <= MAX_COSINE_DISTANCE
             ]
         by_id = {row_id: locator for locator, row_id in locator_ids.items()}
-        return [by_id[row_id] for row_id in ranked_ids]
+        return [(by_id[row_id], float(distance)) for row_id, distance in ranked_ids]
     finally:
         connection.close()
 
@@ -825,6 +838,70 @@ def suppressed_source_pages(matched_pages: list[dict]) -> set[str]:
     return suppressed
 
 
+def emit_ranking_debug(args, sections, ranked, mode, bm25_scores, bm25_ranks,
+                       embedding_ranks, cosine_distances, suppressed) -> None:
+    """Emit every fused candidate with the per-channel numbers behind it.
+
+    `--json` reports the final, rounded, already-limited result set — right for
+    a consumer, useless for anyone asking why a section ranked where it did.
+    The raw BM25 score, the two channel ranks and the cosine distance exist
+    nowhere else, and the candidates dropped by --per-page or provenance dedup
+    never appear in that envelope at all. This one shows the full fused order
+    and annotates each candidate with the limit that would have removed it.
+    """
+    page_counts = Counter()
+    kept = 0
+    candidates = []
+    for score, section_index, retrievers in ranked:
+        section = sections[section_index]
+        page = section["page"]
+        rel_path = page["rel_path"]
+        # Mirrors the real selection loop exactly, in the same order.
+        if rel_path in suppressed:
+            dropped = "dedup_provenance"
+        elif page_counts[rel_path] >= args.per_page:
+            dropped = "per_page"
+        elif kept >= args.top:
+            dropped = "top"
+        else:
+            page_counts[rel_path] += 1
+            kept += 1
+            dropped = None
+        candidates.append({
+            "locator": section_locator(section),
+            "rel_path": rel_path,
+            "section_index": section["section_index"],
+            "heading_path": section["heading_path"],
+            "type": page["meta"].get("type"),
+            "fused_score": score,
+            "retrievers": retrievers,
+            "bm25_score": bm25_scores.get(section_index),
+            "bm25_rank": bm25_ranks.get(section_index),
+            "vector_rank": embedding_ranks.get(section_index),
+            "cosine_distance": cosine_distances.get(section_index),
+            "dropped_by": dropped,
+        })
+    print(json.dumps({
+        "query": args.query,
+        "wiki": str(args.wiki),
+        "mode": mode,
+        # In lexical mode nothing is fused, so the score is the BM25 score.
+        "fused_score_is": "rrf" if mode == "hybrid" else "bm25",
+        "rrf_k": RRF_K,
+        "lexical_candidate_limit": LEXICAL_CANDIDATE_LIMIT,
+        "max_cosine_distance": MAX_COSINE_DISTANCE,
+        "corpus_sections": len(sections),
+        "bm25_hits": len(bm25_scores),
+        "vector_hits": len(embedding_ranks),
+        "limits": {
+            "top": args.top,
+            "per_page": args.per_page,
+            "dedup_provenance": bool(args.dedup_provenance),
+        },
+        "candidates": candidates,
+    }, ensure_ascii=False, indent=2))
+
+
 def cmd_search(args, pages: list[dict]) -> None:
     filtered = [page for page in pages if passes_filters(page, args)]
     if not filtered:
@@ -874,6 +951,11 @@ def cmd_search(args, pages: list[dict]) -> None:
     bm25_ranked = [item for item in bm25_ranked if item[0] > 0]
     ranked = [(score, section_index, ["bm25"]) for score, section_index in bm25_ranked]
     mode = "lexical"
+    # Kept for --debug-ranking: the fused score alone cannot explain itself.
+    bm25_scores = {index: score for score, index in bm25_ranked}
+    bm25_ranks = {index: rank for rank, (_score, index) in enumerate(bm25_ranked, 1)}
+    embedding_ranks: dict[int, int] = {}
+    cosine_distances: dict[int, float] = {}
     if not args.no_embed:
         try:
             all_sections = collect_sections(pages)
@@ -888,11 +970,12 @@ def cmd_search(args, pages: list[dict]) -> None:
                 args.wiki,
             )
             embedding_top = [
-                (0.0, section_indices[locator])
-                for locator in semantic_order
+                (distance, section_indices[locator])
+                for locator, distance in semantic_order
                 if locator in section_indices
             ]
-            lexical_top = bm25_ranked[:50]
+            cosine_distances = {index: distance for distance, index in embedding_top}
+            lexical_top = bm25_ranked[:LEXICAL_CANDIDATE_LIMIT]
             candidate_order = [index for _, index in lexical_top]
             seen_candidates = set(candidate_order)
             for _, index in embedding_top:
@@ -906,10 +989,10 @@ def cmd_search(args, pages: list[dict]) -> None:
                 score = 0.0
                 retrievers = []
                 if index in lexical_ranks:
-                    score += 1.0 / (60 + lexical_ranks[index])
+                    score += 1.0 / (RRF_K + lexical_ranks[index])
                     retrievers.append("bm25")
                 if index in embedding_ranks:
-                    score += 1.0 / (60 + embedding_ranks[index])
+                    score += 1.0 / (RRF_K + embedding_ranks[index])
                     retrievers.append("embedding")
                 ranked.append((score, index, retrievers))
             ranked.sort(key=lambda item: -item[0])
@@ -921,6 +1004,10 @@ def cmd_search(args, pages: list[dict]) -> None:
                 "falling back to lexical",
                 file=sys.stderr,
             )
+            # A half-built semantic view would make --debug-ranking report a
+            # channel that did not actually contribute to `ranked`.
+            embedding_ranks = {}
+            cosine_distances = {}
 
     suppressed = set()
     if args.dedup_provenance:
@@ -934,6 +1021,11 @@ def cmd_search(args, pages: list[dict]) -> None:
                 -item[0],
                 0 if sections[item[1]]["page"]["meta"].get("type") == args.prefer_type else 1,
             ))
+
+    if args.debug_ranking:
+        emit_ranking_debug(args, sections, ranked, mode, bm25_scores, bm25_ranks,
+                           embedding_ranks, cosine_distances, suppressed)
+        return
 
     page_counts = Counter()
     top_sections = []
@@ -1033,11 +1125,17 @@ def main():
     parser.add_argument("--per-page", type=int, default=2,
                         help="Maximum section results per page (default: 2).")
     parser.add_argument("--json", action="store_true", help="Emit structured JSON search results.")
+    parser.add_argument("--debug-ranking", action="store_true",
+                        help="Emit every fused candidate with per-channel scores, ranks and "
+                             "cosine distance, before --top/--per-page/--dedup-provenance.")
     parser.add_argument("--no-embed", action="store_true", help="Force lexical-only search.")
     args = parser.parse_args()
     require_positive(args, "--top", args.top)
     require_positive(args, "--top-linked", args.top_linked)
     require_positive(args, "--per-page", args.per_page)
+    if args.debug_ranking and args.granularity != "section":
+        fail(args, "--debug-ranking explains section-level channel fusion; "
+                   "it has nothing to report at --granularity page.")
     cache_path = None
     if args.cache:
         cache_path = args.wiki / ".wiki-cache" / "search-index.json" if args.cache == "AUTO" else Path(args.cache)

--- a/skills/llm-wiki/scripts/wiki_stats.py
+++ b/skills/llm-wiki/scripts/wiki_stats.py
@@ -17,13 +17,17 @@ import sys
 from collections import Counter
 from pathlib import Path
 
+import wiki_markdown
+from wiki_markdown import configure_utf8_streams, extract_wikilinks
 
-WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+configure_utf8_streams()
+
+
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
 
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "log.md", "README.md"}
-SKIP_TOP_LEVEL_DIRS = {"indexes", "graph", "raw"}
+SKIP_TOP_LEVEL_DIRS = wiki_markdown.SKIP_TOP_LEVEL_DIRS
 
 
 def parse_type(text: str) -> str | None:
@@ -81,7 +85,7 @@ def main():
         total_words += word_count
         # Strip frontmatter before counting wikilinks; frontmatter uses bare slugs.
         body = FRONTMATTER_RE.sub("", text, count=1) if text.startswith("---") else text
-        links = WIKILINK_RE.findall(body)
+        links = extract_wikilinks(body)
         total_links += len(links)
         for link in links:
             target = link.split("|")[0].strip()

--- a/skills/llm-wiki/scripts/wiki_stats.py
+++ b/skills/llm-wiki/scripts/wiki_stats.py
@@ -69,7 +69,7 @@ def main():
             continue
 
         if rel.name == "index.md" and len(rel.parts) == 1:
-            index_lines = text.count("\n") + 1
+            index_lines = len(text.splitlines())
             continue
         if rel.parts[0] in SKIP_TOP_LEVEL_FILES:
             continue
@@ -79,7 +79,7 @@ def main():
             continue
 
         total_pages += 1
-        line_count = text.count("\n") + 1
+        line_count = len(text.splitlines())
         word_count = len(text.split())
         total_lines += line_count
         total_words += word_count

--- a/skills/llm-wiki/tests/test_cache_concurrency.py
+++ b/skills/llm-wiki/tests/test_cache_concurrency.py
@@ -1,0 +1,97 @@
+"""Persisting the parse cache must never fail a query that already answered.
+
+Two agents on one wiki, or a search running beside a benchmark, are ordinary.
+The cache is pure optimization: by the time it is written the results are
+computed, so a writer that loses a race has nothing to report but a warning.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import wiki_search  # noqa: E402
+
+
+def build_wiki(root: Path, pages: int = 20) -> None:
+    (root / "concepts").mkdir(parents=True)
+    for index in range(pages):
+        (root / "concepts" / f"p{index}.md").write_text(
+            f"---\ntype: concept\ntitle: P{index}\n---\n\n# P{index}\n\ngamma delta {index}\n",
+            encoding="utf-8",
+        )
+
+
+class ConcurrentCacheTests(unittest.TestCase):
+    def test_concurrent_writers_neither_fail_nor_corrupt_the_cache(self):
+        # A fixed `<cache>.tmp` name makes writers collide: one writes the
+        # scratch file while another renames it. On Windows that raises
+        # PermissionError from either operation, and the query exits non-zero
+        # with no output at all -- after retrieval had already succeeded.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+            failures: list[str] = []
+            counts: list[int] = []
+            barrier = threading.Barrier(12)
+
+            def worker() -> None:
+                barrier.wait()
+                try:
+                    counts.append(len(wiki_search.collect_pages(root, cache)))
+                except Exception as error:  # noqa: BLE001 - the point is that none escape
+                    failures.append(f"{type(error).__name__}: {error}")
+
+            threads = [threading.Thread(target=worker) for _ in range(12)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+            self.assertEqual([], failures)
+            self.assertEqual({20}, set(counts))
+            # Every scratch file is either renamed into place or cleaned up.
+            self.assertEqual([], list(cache.parent.glob("*.tmp")))
+            payload = json.loads(cache.read_text(encoding="utf-8"))
+            self.assertEqual(wiki_search.PARSE_CACHE_SCHEMA, payload["schema"])
+            self.assertEqual(20, len(payload["files"]))
+
+    def test_an_unwritable_cache_directory_does_not_fail_the_query(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root, pages=3)
+            # A file where the cache directory should be: mkdir and mkstemp both
+            # fail, and the query must still answer.
+            (root / ".wiki-cache").write_text("not a directory", encoding="utf-8")
+
+            pages = wiki_search.collect_pages(root, root / ".wiki-cache" / "search-index.json")
+
+            self.assertEqual(3, len(pages))
+
+    def test_a_failed_rename_leaves_no_scratch_file_behind(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root, pages=2)
+            cache_dir = root / ".wiki-cache"
+            cache_dir.mkdir(parents=True)
+            # A directory occupying the cache path: the write succeeds and the
+            # rename cannot.
+            (cache_dir / "search-index.json").mkdir()
+
+            pages = wiki_search.collect_pages(root, cache_dir / "search-index.json")
+
+            self.assertEqual(2, len(pages))
+            self.assertEqual([], list(cache_dir.glob("*.tmp")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/llm-wiki/tests/test_debug_ranking.py
+++ b/skills/llm-wiki/tests/test_debug_ranking.py
@@ -1,0 +1,110 @@
+"""`--json` is a consumer contract; it is not a diagnostic.
+
+It reports a rounded fused score, the retriever list, and only what survived
+provenance dedup, --per-page and --top. Nothing in it can answer "why did this
+section rank here": the raw BM25 score, the per-channel ranks and the cosine
+distance exist nowhere else, and candidates cut by the page limit never appear
+at all. `--debug-ranking` prints the full fused order and names the limit that
+removed each candidate.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import wiki_search  # noqa: E402
+
+
+class DebugRankingTests(unittest.TestCase):
+    """`--debug-ranking` must explain the ranking, not restate it.
+
+    Its whole reason to exist is that `--json` reports a rounded, already
+    limited result set: the raw BM25 score, both channel ranks and the cosine
+    distance live nowhere else, and candidates cut by --per-page never appear.
+    """
+
+    class _Args:
+        query = "q"
+        wiki = Path("wiki")
+        top = 2
+        per_page = 1
+        dedup_provenance = False
+
+    def _sections(self, specs):
+        sections = []
+        for rel_path, index in specs:
+            page = {"rel_path": rel_path, "meta": {"type": "concept"}, "slug": rel_path}
+            sections.append({"page": page, "section_index": index, "heading_path": ["H"]})
+        return sections
+
+    def _emit(self, args, sections, ranked, mode, **kwargs):
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            wiki_search.emit_ranking_debug(
+                args, sections, ranked, mode,
+                kwargs.get("bm25_scores", {}),
+                kwargs.get("bm25_ranks", {}),
+                kwargs.get("embedding_ranks", {}),
+                kwargs.get("cosine_distances", {}),
+                kwargs.get("suppressed", set()),
+            )
+        return json.loads(buffer.getvalue())
+
+    def test_each_limit_is_named_on_the_candidate_it_removed(self):
+        sections = self._sections([("a.md", 0), ("a.md", 1), ("b.md", 0), ("c.md", 0)])
+        ranked = [(0.9, 0, ["bm25"]), (0.8, 1, ["bm25"]), (0.7, 2, ["bm25"]), (0.6, 3, ["bm25"])]
+        payload = self._emit(self._Args(), sections, ranked, "hybrid")
+
+        self.assertEqual(
+            [None, "per_page", None, "top"],
+            [c["dropped_by"] for c in payload["candidates"]],
+        )
+        # Nothing is hidden: the limits annotate, they do not truncate.
+        self.assertEqual(4, len(payload["candidates"]))
+
+    def test_provenance_dedup_is_named_before_the_page_limit(self):
+        sections = self._sections([("a.md", 0), ("a.md", 1)])
+        ranked = [(0.9, 0, ["bm25"]), (0.8, 1, ["bm25"])]
+        payload = self._emit(self._Args(), sections, ranked, "hybrid", suppressed={"a.md"})
+
+        self.assertEqual(["dedup_provenance", "dedup_provenance"],
+                         [c["dropped_by"] for c in payload["candidates"]])
+
+    def test_per_channel_numbers_survive_into_the_payload(self):
+        sections = self._sections([("a.md", 0)])
+        payload = self._emit(
+            self._Args(), sections, [(0.032522, 0, ["bm25", "embedding"])], "hybrid",
+            bm25_scores={0: 9.215}, bm25_ranks={0: 1},
+            embedding_ranks={0: 2}, cosine_distances={0: 0.287},
+        )
+        candidate = payload["candidates"][0]
+
+        self.assertEqual("a.md\x1f0", candidate["locator"])
+        self.assertEqual(9.215, candidate["bm25_score"])
+        self.assertEqual(1, candidate["bm25_rank"])
+        self.assertEqual(2, candidate["vector_rank"])
+        self.assertEqual(0.287, candidate["cosine_distance"])
+        self.assertEqual("rrf", payload["fused_score_is"])
+        self.assertEqual(wiki_search.RRF_K, payload["rrf_k"])
+
+    def test_lexical_mode_does_not_pass_the_bm25_score_off_as_a_fused_one(self):
+        sections = self._sections([("a.md", 0)])
+        payload = self._emit(self._Args(), sections, [(9.215, 0, ["bm25"])], "lexical",
+                             bm25_scores={0: 9.215}, bm25_ranks={0: 1})
+
+        self.assertEqual("bm25", payload["fused_score_is"])
+        self.assertEqual(0, payload["vector_hits"])
+        self.assertIsNone(payload["candidates"][0]["cosine_distance"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/llm-wiki/tests/test_graph_provenance.py
+++ b/skills/llm-wiki/tests/test_graph_provenance.py
@@ -1,0 +1,198 @@
+"""A `sources:` entry must produce an edge whatever kind of thing it cites.
+
+Entries used to be resolved against wiki slugs alone, and whatever missed was
+dropped. In a wiki whose pages cite repo-relative paths or URLs that empties
+the entire provenance layer while every tool reports success: the extractor
+prints a summary line, lint is clean, and `sourced_from` has zero edges.
+
+These tests therefore pin the resolution rules, not edge counts on any
+particular corpus.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import wiki_graph_extract  # noqa: E402
+import wiki_graph_lint  # noqa: E402
+
+
+ONTOLOGY = SCRIPTS.parent / "assets" / "ontology.yaml.template"
+
+
+def write_page(root: Path, name: str, page_type: str, sources: list[str],
+               body: str = "Body.") -> None:
+    listed = "".join(f"  - {entry}\n" for entry in sources)
+    (root / name).write_text(
+        f"---\ntype: {page_type}\ntitle: {name}\nsources:\n{listed}---\n\n# {name}\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+class DocumentNodeTests(unittest.TestCase):
+    def build(self, root: Path):
+        pages = wiki_graph_extract.collect_pages(root)
+        ontology = wiki_graph_extract.load_ontology(ONTOLOGY)
+        nodes, slug_to_id, _aliases = wiki_graph_extract.build_nodes(pages, ontology)
+        documents, document_ids = wiki_graph_extract.build_document_nodes(pages, slug_to_id)
+        edges = wiki_graph_extract.build_edges(pages, slug_to_id, document_ids)
+        return nodes + documents, edges
+
+    def test_cited_document_becomes_a_node_and_a_sourced_from_edge(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_page(root, "concept-a.md", "concept", ["docs/algorithms/aligner.md"])
+
+            nodes, edges = self.build(root)
+
+            documents = [n for n in nodes if n["node_type"] == "document"]
+            self.assertEqual(["document:docs/algorithms/aligner.md"],
+                             [n["id"] for n in documents])
+            self.assertEqual("aligner.md", documents[0]["title"])
+
+            provenance = [e for e in edges if e["predicate"] == "sourced_from"]
+            self.assertEqual(1, len(provenance))
+            self.assertEqual("document:docs/algorithms/aligner.md", provenance[0]["object"])
+            self.assertEqual("frontmatter_sources", provenance[0]["extraction_method"])
+            self.assertEqual("docs/algorithms/aligner.md", provenance[0]["source"])
+
+    def test_source_page_keeps_the_document_it_summarizes(self):
+        # The guard that skipped source pages exists so a source page does not
+        # claim another wiki page as its provenance. It must not also discard
+        # the edge to the external file the page summarizes -- that is the most
+        # load-bearing provenance edge in the graph.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_page(root, "src-a.md", "source", ["docs/api/parsers.md"])
+
+            _nodes, edges = self.build(root)
+
+            provenance = [e for e in edges if e["predicate"] == "sourced_from"]
+            self.assertEqual(1, len(provenance))
+            self.assertEqual("document:docs/api/parsers.md", provenance[0]["object"])
+
+    def test_source_page_still_refuses_another_wiki_page_as_provenance(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_page(root, "src-a.md", "source", [])
+            write_page(root, "src-b.md", "source", ["src-a"])
+
+            _nodes, edges = self.build(root)
+
+            self.assertEqual([], [e for e in edges if e["predicate"] == "sourced_from"])
+
+    def test_wiki_slug_citation_resolves_to_the_page_not_to_a_document(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_page(root, "src-a.md", "source", [])
+            write_page(root, "concept-a.md", "concept", ["src-a"])
+
+            nodes, edges = self.build(root)
+
+            self.assertEqual([], [n for n in nodes if n["node_type"] == "document"])
+            self.assertEqual(["source:src-a"],
+                             [e["object"] for e in edges if e["predicate"] == "sourced_from"])
+
+    def test_every_edge_object_resolves_to_a_node(self):
+        # A closed graph is the point of minting document nodes at all.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_page(root, "src-a.md", "source", ["docs/one.md"])
+            write_page(root, "concept-a.md", "concept", ["docs/one.md", "docs/two.md"],
+                       body="Links to [[src-a]].")
+
+            nodes, edges = self.build(root)
+
+            known = {n["id"] for n in nodes}
+            self.assertEqual([], [e for e in edges if e["object"] not in known])
+
+    def test_one_document_node_is_shared_by_every_page_citing_it(self):
+        # "Which pages derive from this doc" is the query this makes possible.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_page(root, "concept-a.md", "concept", ["docs/shared.md"])
+            write_page(root, "concept-b.md", "concept", ["docs/shared.md"])
+
+            nodes, edges = self.build(root)
+
+            self.assertEqual(1, len([n for n in nodes if n["node_type"] == "document"]))
+            self.assertEqual(2, len([e for e in edges if e["predicate"] == "sourced_from"]))
+
+    def test_a_page_does_not_cite_itself_into_a_self_edge(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_page(root, "concept-a.md", "concept", ["concept-a"])
+
+            _nodes, edges = self.build(root)
+
+            self.assertEqual([], [e for e in edges if e["predicate"] == "sourced_from"])
+
+
+class UnresolvedSourceLintTests(unittest.TestCase):
+    """The linter, not the compiler, decides whether a citation is real.
+
+    The extractor mints a node for any cited entry so the graph stays closed;
+    that is exactly why something else has to notice a citation pointing at
+    nothing, or the silent-provenance failure just moves one step downstream.
+    """
+
+    def lint(self, wiki: Path, repo_root: Path | None):
+        pages = wiki_graph_lint.collect_pages(wiki)
+        ontology = wiki_graph_extract.load_ontology(ONTOLOGY)
+        return wiki_graph_lint.lint(pages, ontology, repo_root=repo_root)
+
+    @staticmethod
+    def wiki_with(root: Path, sources: list[str]) -> Path:
+        wiki = root / "wiki"
+        wiki.mkdir()
+        write_page(wiki, "concept-a.md", "concept", sources)
+        return wiki
+
+    def test_citation_naming_nothing_is_reported(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            wiki = self.wiki_with(root, ["docs/does-not-exist.md"])
+
+            findings = self.lint(wiki, repo_root=root)
+
+            self.assertEqual(1, len(findings["unresolved_sources"]))
+            self.assertEqual("docs/does-not-exist.md",
+                             findings["unresolved_sources"][0]["source"])
+            self.assertEqual(0, findings["unresolved_sources"][0]["index"])
+
+    def test_existing_repo_file_is_accepted(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            wiki = self.wiki_with(root, ["docs/real.md"])
+            (root / "docs").mkdir()
+            (root / "docs" / "real.md").write_text("# Real\n", encoding="utf-8")
+
+            self.assertEqual([], self.lint(wiki, repo_root=root)["unresolved_sources"])
+
+    def test_a_wiki_slug_is_not_a_missing_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            wiki = root / "wiki"
+            wiki.mkdir()
+            write_page(wiki, "src-a.md", "source", [])
+            write_page(wiki, "concept-a.md", "concept", ["src-a"])
+
+            self.assertEqual([], self.lint(wiki, repo_root=root)["unresolved_sources"])
+
+    def test_check_is_skipped_when_the_repo_root_is_unknown(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            wiki = self.wiki_with(root, ["docs/does-not-exist.md"])
+
+            self.assertEqual([], self.lint(wiki, repo_root=None)["unresolved_sources"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/llm-wiki/tests/test_graph_store.py
+++ b/skills/llm-wiki/tests/test_graph_store.py
@@ -1,0 +1,192 @@
+"""`graph.sqlite` is derived and gitignored, so a fresh clone has none.
+
+Before the rebuild existed, every query exited 1 -- and because consulting the
+graph is an optional step, the agent quietly moved on without typed
+neighbours. The wiki still answered, so a whole retrieval stage could go
+missing with nothing to show for it. That is worse than an error, which is why
+these tests pin the rebuild and, equally, that it does not fire when it should
+not.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import wiki_graph_extract  # noqa: E402
+import wiki_graph_query  # noqa: E402
+import wiki_graph_store  # noqa: E402
+
+
+NODES = [
+    {"id": "concept:a", "slug": "a", "title": "A", "page_type": "concept",
+     "node_type": "concept", "kind": "", "tags": ["t"], "aliases": ["Alpha"],
+     "path": "a.md", "created": "", "updated": "", "canonical": True},
+    {"id": "document:docs/x.md", "slug": "docs/x.md", "title": "x.md",
+     "page_type": "", "node_type": "document", "kind": "", "tags": [],
+     "aliases": [], "path": "docs/x.md", "created": "", "updated": "",
+     "canonical": False},
+]
+EDGES = [
+    {"id": "e1", "subject": "concept:a", "predicate": "sourced_from",
+     "object": "document:docs/x.md", "source": "docs/x.md", "evidence": "",
+     "confidence": "high", "status": "current",
+     "extraction_method": "frontmatter_sources", "page": "a.md", "extras": {}},
+]
+
+
+def write_exports(root: Path) -> Path:
+    graph = root / "graph"
+    graph.mkdir(parents=True)
+    with (graph / "nodes.jsonl").open("w", encoding="utf-8") as handle:
+        for node in NODES:
+            handle.write(json.dumps(node, sort_keys=True) + "\n")
+    with (graph / "edges.jsonl").open("w", encoding="utf-8") as handle:
+        for edge in EDGES:
+            handle.write(json.dumps(edge, sort_keys=True) + "\n")
+    return graph
+
+
+class RebuildFromExportsTests(unittest.TestCase):
+    def test_missing_database_is_rebuilt_from_the_committed_exports(self):
+        with tempfile.TemporaryDirectory() as directory:
+            graph = write_exports(Path(directory))
+            db = graph / "graph.sqlite"
+
+            buffer = io.StringIO()
+            with contextlib.redirect_stderr(buffer):
+                conn = wiki_graph_query.open_db(db, graph)
+            try:
+                self.assertTrue(db.exists())
+                self.assertIn("rebuilding", buffer.getvalue())
+                self.assertEqual(2, conn.execute("SELECT count(*) FROM nodes").fetchone()[0])
+                self.assertEqual(1, conn.execute("SELECT count(*) FROM edges").fetchone()[0])
+                # Aliases are derived from the node rows, not a separate export.
+                self.assertEqual(
+                    ("Alpha", "concept:a"),
+                    tuple(conn.execute("SELECT alias, node_id FROM aliases").fetchone()),
+                )
+            finally:
+                conn.close()
+
+    def test_edges_survive_the_round_trip(self):
+        with tempfile.TemporaryDirectory() as directory:
+            graph = write_exports(Path(directory))
+
+            with contextlib.redirect_stderr(io.StringIO()):
+                conn = wiki_graph_query.open_db(graph / "graph.sqlite", graph)
+            try:
+                row = conn.execute(
+                    "SELECT predicate, object FROM edges WHERE subject = ?",
+                    ("concept:a",)).fetchone()
+                self.assertEqual(("sourced_from", "document:docs/x.md"), tuple(row))
+            finally:
+                conn.close()
+
+    def test_database_older_than_the_exports_is_rebuilt(self):
+        with tempfile.TemporaryDirectory() as directory:
+            graph = write_exports(Path(directory))
+            db = graph / "graph.sqlite"
+            db.write_bytes(b"")
+            stale = (graph / "nodes.jsonl").stat().st_mtime - 60
+            os.utime(db, (stale, stale))
+
+            self.assertEqual("older than the exports",
+                             wiki_graph_query.rebuild_reason(db, graph))
+
+    def test_current_database_is_left_alone(self):
+        with tempfile.TemporaryDirectory() as directory:
+            graph = write_exports(Path(directory))
+            db = graph / "graph.sqlite"
+            db.write_bytes(b"")
+            fresh = (graph / "nodes.jsonl").stat().st_mtime + 60
+            os.utime(db, (fresh, fresh))
+
+            self.assertIsNone(wiki_graph_query.rebuild_reason(db, graph))
+
+    def test_absent_exports_report_instead_of_pretending_to_rebuild(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            graph = root / "graph"
+            graph.mkdir(parents=True)
+
+            self.assertIsNone(wiki_graph_query.rebuild_reason(graph / "graph.sqlite", graph))
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPTS / "wiki_graph_query.py"), str(root),
+                 "neighbors", "--node", "concept:a"],
+                text=True, capture_output=True, encoding="utf-8", check=False)
+
+            self.assertEqual(1, result.returncode)
+            self.assertIn("no exports to rebuild it from", result.stderr)
+
+    def test_a_query_on_a_fresh_clone_answers_instead_of_failing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_exports(root)
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPTS / "wiki_graph_query.py"), str(root),
+                 "--json", "facts", "--about", "concept:a"],
+                text=True, capture_output=True, encoding="utf-8", check=False)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual(["sourced_from"],
+                             [edge["predicate"] for edge in payload["outbound"]])
+
+
+class OneSchemaTwoWritersTests(unittest.TestCase):
+    def test_the_rebuilt_schema_matches_the_extractor(self):
+        # The reason the DDL lives in wiki_graph_store: two writers share it,
+        # and a second copy would diverge exactly as the duplicated corpus
+        # exclusion lists did.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            graph = write_exports(root)
+            from_query = graph / "graph.sqlite"
+            with contextlib.redirect_stderr(io.StringIO()):
+                wiki_graph_query.open_db(from_query, graph).close()
+
+            from_extract = root / "extract.sqlite"
+            wiki_graph_extract._write_sqlite(from_extract, NODES, [], EDGES)
+
+            def shape(path: Path) -> list[str]:
+                conn = sqlite3.connect(path)
+                try:
+                    return sorted(row[0] for row in conn.execute(
+                        "SELECT sql FROM sqlite_master WHERE sql IS NOT NULL"))
+                finally:
+                    conn.close()
+
+            self.assertEqual(shape(from_extract), shape(from_query))
+
+    def test_the_store_reads_only_jsonl_and_needs_no_third_party_import(self):
+        # This module must stay stdlib-only: it is what lets a query rebuild the
+        # database without PyYAML or `uv`, which the extractor both require.
+        source = (SCRIPTS / "wiki_graph_store.py").read_text(encoding="utf-8")
+
+        self.assertNotIn("import yaml", source)
+        with tempfile.TemporaryDirectory() as directory:
+            graph = write_exports(Path(directory))
+            nodes, aliases, edges = wiki_graph_store.read_exports(graph)
+
+            self.assertEqual(2, len(nodes))
+            self.assertEqual(1, len(edges))
+            self.assertEqual([{"alias": "Alpha", "node_id": "concept:a"}], aliases)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/llm-wiki/tests/test_graph_subgraph.py
+++ b/skills/llm-wiki/tests/test_graph_subgraph.py
@@ -1,0 +1,459 @@
+"""How are these pages related? -- the question a retrieval result raises.
+
+Every other subcommand takes exactly one node, so answering it meant one
+`edges --subject` call per page plus hand-filtering the objects back down to
+the set, over output where implicit `mentions` is the majority. `subgraph`
+answers it in one call, in three layers, weakest last: direct edges inside the
+set, then a shared connector two or more members reach, then -- for terms with
+neither -- the chain running between them.
+
+The negatives are load-bearing and tested as such. "Both matched and are
+unrelated" is a finding; an empty edge list alone cannot be told apart from a
+set that was never in the graph.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import contextlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import wiki_graph_query  # noqa: E402
+
+
+def _concept_node(slug: str, *, aliases: tuple[str, ...] = ()) -> dict:
+    return {"id": f"concept:{slug}", "slug": slug, "title": slug.upper(),
+            "page_type": "concept", "node_type": "concept", "kind": "", "tags": [],
+            "aliases": list(aliases), "path": f"concepts/{slug}.md",
+            "created": "", "updated": "", "canonical": True}
+
+
+def _graph_edge(edge_id: str, subject: str, predicate: str, obj: str,
+                evidence: str = "") -> dict:
+    return {"id": edge_id, "subject": subject, "predicate": predicate, "object": obj,
+            "source": "report" if evidence else "", "evidence": evidence,
+            "confidence": "high" if evidence else "low", "status": "current",
+            "extraction_method": "frontmatter" if evidence else "wikilink",
+            "page": f"{subject.split(':', 1)[-1]}.md", "extras": {}}
+
+
+class GraphSubgraphTests(unittest.TestCase):
+    """`subgraph` answers the one question a result set actually raises.
+
+    Every other subcommand takes a single node, so "how are the pages I just
+    retrieved related to each other" cost one `edges --subject` call per page
+    plus hand-filtering the objects back down to the set. The edges that leave
+    the set are the majority and none of them answer that question.
+    """
+
+    NODES = [
+        {"id": "concept:a", "slug": "a", "title": "A", "page_type": "concept",
+         "node_type": "concept", "kind": "", "tags": [], "aliases": ["Alpha"],
+         "path": "concepts/a.md", "created": "", "updated": "", "canonical": True},
+        {"id": "concept:b", "slug": "b", "title": "B", "page_type": "concept",
+         "node_type": "concept", "kind": "", "tags": [], "aliases": ["Shared"],
+         "path": "concepts/b.md", "created": "", "updated": "", "canonical": True},
+        {"id": "concept:c", "slug": "c", "title": "C", "page_type": "concept",
+         "node_type": "concept", "kind": "", "tags": [], "aliases": ["Shared"],
+         "path": "concepts/c.md", "created": "", "updated": "", "canonical": True},
+        {"id": "concept:lonely", "slug": "lonely", "title": "Lonely",
+         "page_type": "concept", "node_type": "concept", "kind": "", "tags": [],
+         "aliases": [], "path": "concepts/lonely.md", "created": "", "updated": "",
+         "canonical": True},
+        {"id": "document:docs/x.md", "slug": "docs/x.md", "title": "x.md",
+         "page_type": "", "node_type": "document", "kind": "", "tags": [],
+         "aliases": [], "path": "docs/x.md", "created": "", "updated": "",
+         "canonical": False},
+    ] + [
+        # The shared-connector shape: x, y, z all touch mid, none touches another.
+        _concept_node(slug) for slug in
+        ("x", "y", "z", "mid",
+         # Two hops apart: far-a — n1 — far-hop — n2 — far-b.
+         "far-a", "far-b", "far-hop", "n1", "n2",
+         # A hub: adjacent to more members than a specific connector would be.
+         "hub", "h1", "h2", "h3",
+         # Joined only by an implicit `mentions` route.
+         "m1", "m2", "gossip",
+         # Reachable from each other only *through* the hub.
+         "bridged-a", "bridged-b")
+    ]
+    EDGES = [
+        {"id": "e1", "subject": "concept:a", "predicate": "depends_on",
+         "object": "concept:b", "source": "", "evidence": "", "confidence": "high",
+         "status": "current", "extraction_method": "frontmatter",
+         "page": "concepts/a.md", "extras": {}},
+        {"id": "e2", "subject": "concept:b", "predicate": "mentions",
+         "object": "concept:c", "source": "", "evidence": "", "confidence": "low",
+         "status": "current", "extraction_method": "wikilink",
+         "page": "concepts/b.md", "extras": {}},
+        # Leaves the set: the noise `subgraph` exists to drop.
+        {"id": "e3", "subject": "concept:a", "predicate": "sourced_from",
+         "object": "document:docs/x.md", "source": "docs/x.md", "evidence": "",
+         "confidence": "high", "status": "current",
+         "extraction_method": "frontmatter_sources", "page": "concepts/a.md",
+         "extras": {}},
+        _graph_edge("c1", "concept:x", "depends_on", "concept:mid",
+                    "x consumes the mid estimate"),
+        _graph_edge("c2", "concept:y", "relates_to", "concept:mid", "y derives from mid"),
+        _graph_edge("c3", "concept:z", "relates_to", "concept:mid", "z derives from mid"),
+        _graph_edge("f1", "concept:far-a", "relates_to", "concept:n1", "a—n1"),
+        _graph_edge("f2", "concept:n1", "relates_to", "concept:far-hop", "n1—hop"),
+        _graph_edge("f3", "concept:far-hop", "relates_to", "concept:n2", "hop—n2"),
+        _graph_edge("f4", "concept:n2", "relates_to", "concept:far-b", "n2—b"),
+        _graph_edge("g1", "concept:hub", "relates_to", "concept:h1", "hub—h1"),
+        _graph_edge("g2", "concept:hub", "relates_to", "concept:h2", "hub—h2"),
+        _graph_edge("g3", "concept:hub", "relates_to", "concept:h3", "hub—h3"),
+        _graph_edge("n_1", "concept:m1", "mentions", "concept:gossip"),
+        _graph_edge("n_2", "concept:m2", "mentions", "concept:gossip"),
+        _graph_edge("b1", "concept:bridged-a", "relates_to", "concept:hub", "a—hub"),
+        _graph_edge("b2", "concept:bridged-b", "relates_to", "concept:hub", "b—hub"),
+    ]
+
+    def _conn(self, root: Path) -> sqlite3.Connection:
+        graph = root / "graph"
+        graph.mkdir(parents=True)
+        with (graph / "nodes.jsonl").open("w", encoding="utf-8") as handle:
+            for node in self.NODES:
+                handle.write(json.dumps(node, sort_keys=True) + "\n")
+        with (graph / "edges.jsonl").open("w", encoding="utf-8") as handle:
+            for edge in self.EDGES:
+                handle.write(json.dumps(edge, sort_keys=True) + "\n")
+        with contextlib.redirect_stderr(io.StringIO()):
+            return wiki_graph_query.open_db(graph / "graph.sqlite", graph)
+
+    def _subgraph(self, conn, nodes: list[str], predicate: str | None = None,
+                  radius: int | None = 0, max_connector_degree: int = 25,
+                  include_mentions: bool = False, max_chain_hops: int = 0) -> dict:
+        """`radius=0` and no chains by default: most cases pin the induced half."""
+        return wiki_graph_query.cmd_subgraph(
+            conn, argparse.Namespace(
+                nodes=nodes, predicate=predicate, radius=radius,
+                max_connector_degree=max_connector_degree,
+                include_mentions=include_mentions, max_chain_hops=max_chain_hops,
+            )
+        )
+
+    def test_only_edges_with_both_ends_in_the_set_are_returned(self):
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(conn, ["concept:a,concept:b,concept:c"])
+                self.assertEqual(
+                    [("concept:a", "depends_on", "concept:b"),
+                     ("concept:b", "mentions", "concept:c")],
+                    [(e["subject"], e["predicate"], e["object"]) for e in result["edges"]],
+                )
+                # e3's object is outside the set, so it never appears.
+                self.assertNotIn("sourced_from", [e["predicate"] for e in result["edges"]])
+            finally:
+                conn.close()
+
+    def test_predicate_filter_narrows_to_the_typed_layer(self):
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(conn, ["concept:a,concept:b,concept:c"],
+                                        predicate="depends_on")
+                self.assertEqual(1, len(result["edges"]))
+                self.assertEqual("depends_on", result["edges"][0]["predicate"])
+            finally:
+                conn.close()
+
+    def test_a_node_with_no_internal_edge_is_reported_as_isolated(self):
+        """The informative negative: both pages matched and are unrelated."""
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(conn, ["concept:a,concept:b,concept:lonely"])
+                self.assertEqual(["concept:lonely"], result["isolated"])
+            finally:
+                conn.close()
+
+    def test_bare_slugs_resolve_because_search_reports_slugs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                by_slug = self._subgraph(conn, ["a,b"])
+                by_id = self._subgraph(conn, ["concept:a,concept:b"])
+                self.assertEqual(
+                    [e["id"] for e in by_id["edges"]], [e["id"] for e in by_slug["edges"]]
+                )
+                self.assertEqual(["concept:a", "concept:b"],
+                                 [n["id"] for n in by_slug["nodes"]])
+            finally:
+                conn.close()
+
+    def test_a_unique_alias_resolves_and_an_ambiguous_one_does_not(self):
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                self.assertEqual("concept:a", wiki_graph_query.resolve_node_id(conn, "Alpha"))
+                # "Shared" names both b and c: picking one silently would be a lie.
+                self.assertIsNone(wiki_graph_query.resolve_node_id(conn, "Shared"))
+            finally:
+                conn.close()
+
+    def test_one_unknown_token_is_reported_without_losing_the_rest(self):
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(conn, ["concept:a", "concept:b,concept:ghost"])
+                self.assertEqual(["concept:ghost"], result["unresolved"])
+                self.assertEqual(1, len(result["edges"]))
+            finally:
+                conn.close()
+
+    def test_the_same_node_named_twice_is_counted_once(self):
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(conn, ["concept:a,a,Alpha"])
+                self.assertEqual(1, len(result["nodes"]))
+                self.assertEqual(3, len(result["requested"]))
+            finally:
+                conn.close()
+
+    def test_repeated_query_reuses_the_temp_table_without_leaking_rows(self):
+        """`--nodes` twice in one process must not union the two sets."""
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                self._subgraph(conn, ["concept:a,concept:b"])
+                second = self._subgraph(conn, ["concept:b,concept:c"])
+                self.assertEqual(
+                    [("concept:b", "mentions", "concept:c")],
+                    [(e["subject"], e["predicate"], e["object"]) for e in second["edges"]],
+                )
+            finally:
+                conn.close()
+
+    def test_all_tokens_unknown_exits_one(self):
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                buffer = io.StringIO()
+                with contextlib.redirect_stderr(buffer):
+                    with self.assertRaises(SystemExit) as exit_context:
+                        self._subgraph(conn, ["ghost,phantom"])
+                self.assertEqual(1, exit_context.exception.code)
+                self.assertIn("none of the requested nodes", buffer.getvalue())
+            finally:
+                conn.close()
+
+    def test_an_empty_node_list_exits_two(self):
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                with contextlib.redirect_stderr(io.StringIO()):
+                    with self.assertRaises(SystemExit) as exit_context:
+                        self._subgraph(conn, [" , "])
+                self.assertEqual(2, exit_context.exception.code)
+            finally:
+                conn.close()
+
+    def test_a_shared_connector_is_found_without_being_asked_for(self):
+        """The point of the default: three members, no direct edge, one shared step."""
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(conn, ["concept:x,concept:y,concept:z"], radius=None)
+                self.assertEqual(1, result["radius"])
+                self.assertEqual(["concept:mid"], [c["id"] for c in result["connectors"]])
+                self.assertEqual(3, len(result["connectors"][0]["joins"]))
+                self.assertEqual([], result["isolated"])
+            finally:
+                conn.close()
+
+    def test_a_connector_reached_from_only_one_member_is_not_one(self):
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(conn, ["concept:x,concept:lonely"], radius=1)
+                self.assertEqual([], [c["id"] for c in result["connectors"]])
+            finally:
+                conn.close()
+
+    def test_radius_widens_only_when_the_close_search_finds_nothing(self):
+        """`far` sits two hops from x and y — invisible at radius 1, found at 2."""
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                near = self._subgraph(conn, ["concept:far-a,concept:far-b"], radius=1)
+                self.assertEqual([], [c["id"] for c in near["connectors"]])
+
+                auto = self._subgraph(conn, ["concept:far-a,concept:far-b"], radius=None)
+                self.assertEqual(2, auto["radius"])
+                self.assertIn("concept:far-hop", [c["id"] for c in auto["connectors"]])
+            finally:
+                conn.close()
+
+    def test_a_hub_is_excluded_and_reported_rather_than_hidden(self):
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                capped = self._subgraph(conn, ["concept:h1,concept:h2"],
+                                        radius=1, max_connector_degree=2)
+                self.assertEqual([], [c["id"] for c in capped["connectors"]])
+                self.assertEqual(["concept:hub"], [h["id"] for h in capped["excluded_hubs"]])
+
+                uncapped = self._subgraph(conn, ["concept:h1,concept:h2"],
+                                          radius=1, max_connector_degree=0)
+                self.assertEqual(["concept:hub"], [c["id"] for c in uncapped["connectors"]])
+            finally:
+                conn.close()
+
+    def test_a_hub_may_not_be_walked_through(self):
+        """Regression: excluding a hub as a candidate is not enough.
+
+        `bridged-a` and `bridged-b` touch nothing but the hub. If the walk may
+        pass through it, every other neighbour of the hub becomes "reachable from
+        both members" at radius 2, and the command answers a relational question
+        with most of the corpus — measured at a median of 193 connectors per
+        random triple on the real graph before this was fixed.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(conn, ["concept:bridged-a,concept:bridged-b"],
+                                        radius=None, max_connector_degree=4)
+                self.assertEqual([], [c["id"] for c in result["connectors"]])
+                self.assertEqual(["concept:hub"], [h["id"] for h in result["excluded_hubs"]])
+                self.assertEqual(2, result["radius"], "should have widened and still found none")
+            finally:
+                conn.close()
+
+    def test_mentions_routes_are_off_by_default_and_opt_in(self):
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                typed_only = self._subgraph(conn, ["concept:m1,concept:m2"], radius=1)
+                self.assertEqual([], [c["id"] for c in typed_only["connectors"]])
+
+                widened = self._subgraph(conn, ["concept:m1,concept:m2"], radius=1,
+                                         include_mentions=True)
+                self.assertEqual(["concept:gossip"], [c["id"] for c in widened["connectors"]])
+            finally:
+                conn.close()
+
+    def test_connector_edges_carry_their_evidence_into_the_result(self):
+        """Without the edges the connector is an assertion; with them it is sourced."""
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(conn, ["concept:x,concept:y,concept:z"], radius=None)
+                evidence = [e["evidence"] for e in result["edges"] if e["evidence"]]
+                self.assertIn("x consumes the mid estimate", evidence)
+            finally:
+                conn.close()
+
+    def test_distant_terms_come_back_as_a_chain(self):
+        """The primary case: far-a and far-b share no neighbour, only a route.
+
+        `far-a — n1 — far-hop — n2 — far-b` is four hops. A connector search can
+        never express it, which is why chains exist.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(conn, ["concept:far-a,concept:far-b"],
+                                        radius=None, max_chain_hops=4)
+                self.assertEqual(1, len(result["chains"]))
+                chain = result["chains"][0]
+                self.assertEqual(
+                    ["concept:far-a", "concept:n1", "concept:far-hop",
+                     "concept:n2", "concept:far-b"], chain["nodes"])
+                self.assertEqual(4, chain["hops"])
+                self.assertEqual("typed", chain["scope"])
+                self.assertEqual(4, len(chain["edges"]))
+            finally:
+                conn.close()
+
+    def test_the_route_nodes_join_the_reported_subgraph(self):
+        """'Bounded by the terms' means the intermediates are part of the answer."""
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(conn, ["concept:far-a,concept:far-b"],
+                                        radius=None, max_chain_hops=4)
+                subjects = {edge["subject"] for edge in result["edges"]}
+                objects = {edge["object"] for edge in result["edges"]}
+                self.assertIn("concept:far-hop", subjects | objects)
+            finally:
+                conn.close()
+
+    def test_a_pair_beyond_the_limit_reports_its_distance_not_silence(self):
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(conn, ["concept:far-a,concept:far-b"],
+                                        radius=None, max_chain_hops=2)
+                self.assertEqual([], result["chains"])
+                self.assertEqual(
+                    [{"from": "concept:far-a", "to": "concept:far-b",
+                      "beyond_limit_hops": 4, "scope": "typed+mentions"}],
+                    result["unreachable"],
+                )
+            finally:
+                conn.close()
+
+    def test_a_route_that_needs_wikilinks_says_so(self):
+        """m1 and m2 are joined only by `mentions`; the chain must not hide that."""
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(conn, ["concept:m1,concept:m2"],
+                                        radius=None, max_chain_hops=4)
+                self.assertEqual(1, len(result["chains"]))
+                self.assertEqual("typed+mentions", result["chains"][0]["scope"])
+                self.assertEqual("mentions", result["chains"][0]["weakest"])
+            finally:
+                conn.close()
+
+    def test_a_chain_may_not_run_through_a_hub(self):
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(conn, ["concept:bridged-a,concept:bridged-b"],
+                                        radius=None, max_chain_hops=4,
+                                        max_connector_degree=4)
+                self.assertEqual([], result["chains"])
+                self.assertEqual([], result["unreachable"],
+                                 "a hub route is no route, not a longer one")
+            finally:
+                conn.close()
+
+    def test_chains_are_off_when_the_hop_limit_is_zero(self):
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(conn, ["concept:far-a,concept:far-b"],
+                                        radius=None, max_chain_hops=0)
+                self.assertEqual([], result["chains"])
+            finally:
+                conn.close()
+
+    def test_render_names_the_isolated_and_the_missing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            conn = self._conn(Path(directory))
+            try:
+                result = self._subgraph(
+                    conn, ["concept:a,concept:b,concept:lonely,concept:ghost"]
+                )
+                text = wiki_graph_query.render(result, "subgraph")
+                self.assertIn("Unconnected even through a connector: concept:lonely", text)
+                self.assertIn("Not in the graph: concept:ghost", text)
+            finally:
+                conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/llm-wiki/tests/test_json_contract.py
+++ b/skills/llm-wiki/tests/test_json_contract.py
@@ -1,0 +1,153 @@
+"""`--json` is a consumer contract, so it holds on the failure paths too.
+
+Every test here drives the real CLI in a subprocess. That is the point: the
+failures being pinned down are argparse's own error path, an early `return`,
+and a bare `sys.exit`, none of which are visible from an in-process call.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def build_wiki(root: Path, names: tuple[str, ...] = ("alpha",)) -> None:
+    (root / "concepts").mkdir(parents=True)
+    for name in names:
+        (root / "concepts" / f"{name}.md").write_text(
+            f"---\ntype: concept\ntitle: {name}\n---\n\n# {name}\n\nGamma delta.\n",
+            encoding="utf-8",
+        )
+
+
+def run_search(root: Path, *extra: str, json_mode: bool = True) -> subprocess.CompletedProcess:
+    command = [sys.executable, str(SCRIPTS / "wiki_search.py"), *extra,
+               "--wiki", str(root), "--no-embed"]
+    if json_mode:
+        command.append("--json")
+    return subprocess.run(command, capture_output=True, text=True, encoding="utf-8")
+
+
+class JsonEnvelopeTests(unittest.TestCase):
+    def test_untokenizable_query_still_returns_json_and_fails(self):
+        # The tokenizer keeps [a-z0-9]+, so a query in a non-Latin script has
+        # nothing to match. That used to print "Empty query." to stderr and
+        # return, leaving stdout empty with exit code 0 -- indistinguishable
+        # from a crash to anything parsing the output.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+
+            result = run_search(root, "вирівнювання")
+            payload = json.loads(result.stdout)
+
+            self.assertEqual(2, result.returncode)
+            self.assertEqual([], payload["results"])
+            self.assertIn("no searchable tokens", payload["error"])
+
+    def test_missing_query_returns_json_instead_of_help(self):
+        # An empty query printed argparse help to stdout, which is neither JSON
+        # nor an error code.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+
+            result = run_search(root, "")
+            payload = json.loads(result.stdout)
+
+            self.assertEqual(2, result.returncode)
+            self.assertIsNotNone(payload["error"])
+
+    def test_a_missing_wiki_is_reported_in_the_envelope(self):
+        with tempfile.TemporaryDirectory() as directory:
+            result = run_search(Path(directory) / "absent", "gamma")
+            payload = json.loads(result.stdout)
+
+            self.assertEqual(1, result.returncode)
+            self.assertIn("not found", payload["error"])
+
+    def test_an_empty_wiki_is_reported_in_the_envelope(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            root.mkdir()
+
+            result = run_search(root, "gamma")
+            payload = json.loads(result.stdout)
+
+            self.assertEqual(0, result.returncode)
+            self.assertEqual([], payload["results"])
+            self.assertIn("No wiki pages", payload["error"])
+
+    def test_successful_query_reports_no_error(self):
+        # `error` is present and null on success, so a consumer branches on one
+        # field rather than on whether stdout happened to be empty.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+
+            result = run_search(root, "gamma")
+            payload = json.loads(result.stdout)
+
+            self.assertEqual(0, result.returncode)
+            self.assertIn("error", payload)
+            self.assertIsNone(payload["error"])
+            self.assertEqual("alpha", payload["results"][0]["slug"])
+
+
+class CountArgumentTests(unittest.TestCase):
+    """Count flags are rejected up front instead of failing three different ways."""
+
+    def test_non_positive_counts_fail_with_a_parseable_envelope(self):
+        # Raw `type=int` let each of these through, and each failed silently and
+        # differently: --top 0 returned one section but no pages, a negative
+        # --top-linked became a negative list slice, and --per-page 0 dropped
+        # every result while still exiting 0.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root, ("alpha", "beta"))
+
+            for flag, value in (("--top", "0"), ("--top", "-1"),
+                                ("--top-linked", "-1"), ("--per-page", "0")):
+                with self.subTest(flag=flag, value=value):
+                    result = run_search(root, "gamma", flag, value)
+                    payload = json.loads(result.stdout)
+
+                    self.assertEqual(2, result.returncode)
+                    self.assertEqual([], payload["results"])
+                    self.assertIn(flag, payload["error"])
+                    self.assertIn("positive", payload["error"])
+
+    def test_without_json_the_same_rejection_goes_to_stderr(self):
+        # Validating in `type=` would route this through argparse's usage text,
+        # which no structured consumer can read -- hence the check after
+        # parse_args() and the shared fail() helper.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root, ("alpha", "beta"))
+
+            result = run_search(root, "gamma", "--per-page", "0", json_mode=False)
+
+            self.assertEqual(2, result.returncode)
+            self.assertIn("--per-page", result.stderr)
+            self.assertEqual("", result.stdout)
+
+    def test_positive_counts_still_work(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root, ("alpha", "beta"))
+
+            result = run_search(root, "gamma", "--top", "1")
+
+            self.assertEqual(0, result.returncode)
+            self.assertEqual(1, len(json.loads(result.stdout)["results"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/llm-wiki/tests/test_lint_and_stats.py
+++ b/skills/llm-wiki/tests/test_lint_and_stats.py
@@ -1,0 +1,191 @@
+"""Lint and stats are the tools a hook or a CI job runs, so they owe an
+exit code and an honest line count.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import wiki_lint  # noqa: E402
+
+
+ONTOLOGY = SCRIPTS.parent / "assets" / "ontology.yaml.template"
+
+
+class IndexShardCapTests(unittest.TestCase):
+    """Index shards keep discovery bounded, so they are capped like any page."""
+
+    def lint_index(self, line_count: int, trailing_newline: bool = True) -> dict:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            indexes = root / "indexes" / "nested"
+            indexes.mkdir(parents=True)
+            text = "\n".join(["entry"] * line_count)
+            if trailing_newline:
+                text += "\n"
+            (indexes / "concepts.md").write_text(text, encoding="utf-8")
+            return wiki_lint.lint([], 400, 800, [], False, 5, wiki_root=root)
+
+    def test_exactly_the_cap_is_allowed_even_with_a_trailing_newline(self):
+        self.assertEqual([], self.lint_index(wiki_lint.INDEX_SHARD_LINE_CAP)["oversized_indexes"])
+
+    def test_one_line_over_the_cap_is_reported(self):
+        over = wiki_lint.INDEX_SHARD_LINE_CAP + 1
+        findings = self.lint_index(over)["oversized_indexes"]
+
+        self.assertEqual(1, len(findings))
+        self.assertEqual(over, findings[0]["lines"])
+        self.assertEqual("indexes/nested/concepts.md", findings[0]["path"].replace("\\", "/"))
+
+    def test_the_root_index_is_subject_to_the_same_limit(self):
+        # Otherwise a wiki can silently outgrow the entry point whose whole job
+        # is to keep discovery bounded.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "index.md").write_text(
+                "\n".join(["entry"] * (wiki_lint.INDEX_SHARD_LINE_CAP + 1)) + "\n",
+                encoding="utf-8")
+
+            findings = wiki_lint.lint([], 400, 800, [], False, 5, wiki_root=root)
+
+            self.assertEqual(
+                [("index.md", wiki_lint.INDEX_SHARD_LINE_CAP + 1)],
+                [(item["path"].replace("\\", "/"), item["lines"])
+                 for item in findings["oversized_indexes"]],
+            )
+
+
+class IndexOrphanExemptionTests(unittest.TestCase):
+    def test_an_index_page_is_never_an_orphan(self):
+        # Index pages are navigational roots reached from index.md, and index.md
+        # is excluded as a link source -- so every index shard looked orphaned.
+        def page(slug: str, rel_path: str, page_type: str) -> dict:
+            return {"slug": slug, "rel_path": rel_path, "meta": {"type": page_type},
+                    "links": [], "line_count": 10, "malformed_fm": False, "body": ""}
+
+        pages = [
+            page("concepts-index", "indexes/concepts.md", "index"),
+            page("lonely", "concepts/lonely.md", "concept"),
+        ]
+
+        findings = wiki_lint.lint(pages, 400, 800, [], False, 5)
+
+        self.assertEqual(["lonely"], [item["slug"] for item in findings["orphans"]])
+
+
+class LintExitCodeTests(unittest.TestCase):
+    def test_the_cli_fails_for_an_oversized_index(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "indexes").mkdir()
+            (root / "indexes" / "concepts.md").write_text(
+                "\n".join(["entry"] * (wiki_lint.INDEX_SHARD_LINE_CAP + 1)) + "\n",
+                encoding="utf-8")
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPTS / "wiki_lint.py"), str(root)],
+                text=True, capture_output=True, encoding="utf-8", check=False)
+
+            self.assertEqual(1, result.returncode)
+            self.assertIn("Index over cap", result.stdout)
+
+    def test_a_clean_wiki_still_exits_zero(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "concepts").mkdir()
+            (root / "concepts" / "a.md").write_text(
+                "---\ntype: concept\ntitle: A\n---\n\n# A\n\n[[b]]\n", encoding="utf-8")
+            (root / "concepts" / "b.md").write_text(
+                "---\ntype: concept\ntitle: B\n---\n\n# B\n\n[[a]]\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPTS / "wiki_lint.py"), str(root),
+                 "--required-fm", "type,title"],
+                text=True, capture_output=True, encoding="utf-8", check=False)
+
+            self.assertEqual(0, result.returncode, result.stdout)
+
+
+class GraphLintTests(unittest.TestCase):
+    def build(self, root: Path, source: str) -> None:
+        (root / "graph").mkdir()
+        (root / "graph" / "ontology.yaml").write_text(
+            ONTOLOGY.read_text(encoding="utf-8"), encoding="utf-8")
+        (root / "subject.md").write_text(
+            "---\n"
+            "type: concept\n"
+            "title: Subject\n"
+            "graph:\n"
+            "  relationships:\n"
+            "    - predicate: depends_on\n"
+            "      object: concept:other\n"
+            f"      source: {source}\n"
+            "      evidence: deliberate test fixture\n"
+            "      confidence: high\n"
+            "      status: current\n"
+            "---\n"
+            "\n# Subject\n",
+            encoding="utf-8")
+        (root / "other.md").write_text(
+            "---\ntype: concept\ntitle: Other\n---\n\n# Other\n", encoding="utf-8")
+
+    def run_lint(self, root: Path) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(SCRIPTS / "wiki_graph_lint.py"), str(root)],
+            text=True, capture_output=True, encoding="utf-8", check=False)
+
+    def test_a_page_may_cite_itself_as_the_source_of_an_edge_it_declares(self):
+        # SCHEMA calls the field a "source/derived page slug". Requiring a
+        # `source`-type page left a derived page no correct way to record the
+        # provenance of an edge it is itself the evidence for.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.build(root, "subject")
+
+            result = self.run_lint(root)
+
+            self.assertEqual(0, result.returncode, result.stdout)
+
+    def test_a_source_naming_nothing_is_still_reported(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.build(root, "no-such-page")
+
+            result = self.run_lint(root)
+
+            self.assertEqual(1, result.returncode)
+            self.assertIn("source: does not match any source page", result.stdout)
+            # Windows: the report carries em dashes, and a redirected stdout
+            # defaults to cp1252 there.
+            self.assertNotIn("UnicodeEncodeError", result.stderr)
+
+
+class WikiStatsContractTests(unittest.TestCase):
+    def test_a_trailing_newline_does_not_inflate_reported_line_counts(self):
+        # `text.count("\n") + 1` counts a phantom last line on every file that
+        # ends with a newline -- which is every well-formed file.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "index.md").write_text("# Index\n\nSecond line\n", encoding="utf-8")
+            (root / "page.md").write_text(
+                "---\ntype: concept\ntitle: Page\n---\n\n# Page\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPTS / "wiki_stats.py"), str(root)],
+                text=True, capture_output=True, encoding="utf-8", check=False)
+
+            self.assertEqual(0, result.returncode)
+            self.assertRegex(result.stdout, r"Total lines:\s+6\b")
+            self.assertRegex(result.stdout, r"index\.md:\s+3 lines\b")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/llm-wiki/tests/test_markdown.py
+++ b/skills/llm-wiki/tests/test_markdown.py
@@ -1,0 +1,317 @@
+"""Business rules for the shared Markdown layer.
+
+Two contracts are under test, and they are the reason the module exists:
+
+* a ``[[wikilink]]`` becomes a backlink and a graph edge only when a Markdown
+  reader would see it as prose, never when it is code or raw HTML;
+* every tool agrees on which files are wiki pages at all.
+
+Both used to be decided per script, and both had already drifted.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+import sys  # noqa: E402
+
+sys.path.insert(0, str(SCRIPTS))
+
+import wiki_graph_extract  # noqa: E402
+import wiki_graph_lint  # noqa: E402
+import wiki_lint  # noqa: E402
+import wiki_markdown  # noqa: E402
+import wiki_search  # noqa: E402
+import wiki_stats  # noqa: E402
+
+
+class NavigableLinkContractTests(unittest.TestCase):
+    """A link is navigable only when a Markdown reader would see it as prose."""
+
+    def test_extracts_aliases_and_escaped_table_aliases(self):
+        body = "[[plain]] [[shown|Alias]] [[table\\|Table alias]] [[#local]]"
+        self.assertEqual(
+            ["plain", "shown", "table"],
+            wiki_markdown.extract_wikilinks(body),
+        )
+
+    def test_escaped_wikilink_is_literal_but_even_backslashes_leave_it_visible(self):
+        body = r"\[[escaped]] \\[[visible]] [[ordinary]]"
+        self.assertEqual(
+            ["visible", "ordinary"],
+            wiki_markdown.extract_wikilinks(body),
+        )
+
+    def test_blank_target_and_local_anchor_do_not_create_graph_nodes(self):
+        body = "[[   ]] [[#installation]] [[guide#installation|Install]]"
+        self.assertEqual(["guide"], wiki_markdown.extract_wikilinks(body))
+
+    def test_cross_page_anchor_resolves_to_page_and_multiline_link_is_rejected(self):
+        body = "[[page#section|Section]] [[broken\nlink]] [[real]]"
+        self.assertEqual(["page", "real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_ignores_inline_code(self):
+        body = "`[[one]]` ``code ` [[two]]`` [[real]]"
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_unmatched_backtick_is_prose_not_an_open_ended_code_span(self):
+        body = "An unmatched ` delimiter leaves [[the-link]] visible."
+        self.assertEqual(["the-link"], wiki_markdown.extract_wikilinks(body))
+
+    def test_code_span_delimiters_must_have_equal_length(self):
+        body = "``code ` [[hidden]] `` [[visible]]"
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_escaped_backticks_do_not_create_code_spans(self):
+        body = r"\`[[visible]]\` [[real]]"
+        self.assertEqual(["visible", "real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_code_spans_do_not_cross_paragraph_boundaries(self):
+        body = "`open\n\n[[visible]]\n\nclose` [[also-visible]]"
+        self.assertEqual(
+            ["visible", "also-visible"],
+            wiki_markdown.extract_wikilinks(body),
+        )
+
+    def test_code_span_does_not_cross_heading_or_thematic_break_blocks(self):
+        body = "`open\n# [[heading]]\n\n`open\n---\n[[after-break]]"
+        self.assertEqual(
+            ["heading", "after-break"],
+            wiki_markdown.extract_wikilinks(body),
+        )
+
+    def test_code_span_does_not_cross_setext_heading_boundary(self):
+        body = "`heading\n===\n[[visible]]`"
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_ordered_marker_other_than_one_does_not_interrupt_paragraph(self):
+        body = "paragraph\n2.     [[visible-continuation]]"
+        self.assertEqual(
+            ["visible-continuation"],
+            wiki_markdown.extract_wikilinks(body),
+        )
+
+    def test_indentation_does_not_interrupt_a_paragraph(self):
+        body = "paragraph\n    [[continuation]]\n"
+        self.assertEqual(["continuation"], wiki_markdown.extract_wikilinks(body))
+
+
+class LiteralBlockContractTests(unittest.TestCase):
+    """Examples and raw code must never become backlinks or graph edges."""
+
+    def test_ignores_four_character_fence_containing_triple_fence(self):
+        body = "````md\n[[fake]]\n```\n````\n[[real]]\n"
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_accepts_longer_closing_fence(self):
+        body = "```md\n[[fake]]\n`````\n[[real]]\n"
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_ignores_tilde_fence(self):
+        body = "~~~~\n[[fake]]\n~~~~\n[[real]]\n"
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_wrong_fence_character_and_short_fence_do_not_close_block(self):
+        body = (
+            "````\n[[hidden-a]]\n~~~\n[[hidden-b]]\n```\n[[hidden-c]]\n"
+            "````\n[[visible]]"
+        )
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_closing_fence_with_trailing_text_is_not_a_closer(self):
+        body = "```\n[[hidden-a]]\n``` trailing\n[[hidden-b]]\n```\n[[visible]]"
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_backtick_in_backtick_fence_info_invalidates_the_opener(self):
+        body = "```language`option\n[[visible]]"
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_unclosed_fence_consumes_rest_of_document(self):
+        body = "[[before]]\n```\n[[inside]]\n"
+        self.assertEqual(["before"], wiki_markdown.extract_wikilinks(body))
+
+    def test_indented_code_and_tab_indented_code_are_ignored(self):
+        body = "    [[space-code]]\n\n\t[[tab-code]]\n\n[[real]]"
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_excess_list_padding_creates_indented_code(self):
+        body = "-     [[indented-code]]\n\n- [[visible-item]]"
+        self.assertEqual(["visible-item"], wiki_markdown.extract_wikilinks(body))
+
+    def test_tab_padded_list_continuation_keeps_code_in_the_list(self):
+        # The blank line is significant: indented code cannot interrupt the
+        # preceding paragraph, even inside a list item.
+        body = "- item\n\n\t    [[hidden]]\n\n[[visible]]"
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_fences_inside_blockquotes_and_lists_are_ignored(self):
+        body = (
+            "> ~~~~\n> [[quoted]]\n> ~~~~~\n\n"
+            "10. item\n    ```\n    [[listed]]\n    ````\n\n"
+            "[[real]]"
+        )
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_fences_in_mixed_list_and_blockquote_containers_are_ignored(self):
+        body = (
+            "- > ```\n  > [[list-quote]]\n  > ```\n\n"
+            "> - ~~~\n>   [[quote-list]]\n>   ~~~\n\n"
+            "[[real]]"
+        )
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_block_markers_inside_open_fences_are_literal_code(self):
+        bodies = (
+            "```\n- [[hidden-list]]\n> [[hidden-quote]]\n```\n[[visible]]",
+            "- ```\n  - [[hidden-list]]\n  > [[hidden-quote]]\n  ```\n[[visible]]",
+            "> ```\n> - [[hidden-list]]\n> > [[hidden-quote]]\n> ```\n[[visible]]",
+        )
+        for body in bodies:
+            with self.subTest(body=body):
+                self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_unclosed_container_fence_ends_with_its_container(self):
+        body = "> ```\n> [[quoted]]\n\n[[outside]]"
+        self.assertEqual(["outside"], wiki_markdown.extract_wikilinks(body))
+
+    def test_unclosed_fence_ends_when_nested_list_item_ends(self):
+        body = (
+            "- outer\n"
+            "  - inner\n"
+            "    ```\n"
+            "    [[hidden]]\n"
+            "  [[outer-visible]]\n"
+        )
+        self.assertEqual(["outer-visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_empty_list_item_still_owns_its_indented_fence(self):
+        body = "-\n  ```\n  [[hidden]]\n[[outside]]\n"
+        self.assertEqual(["outside"], wiki_markdown.extract_wikilinks(body))
+
+    def test_root_and_blockquote_fence_matrix(self):
+        for prefix in ("", "> ", "> > "):
+            for character in ("`", "~"):
+                for opening_length in range(3, 7):
+                    for extra_closing in range(3):
+                        with self.subTest(prefix=prefix, character=character,
+                                          opening=opening_length, extra=extra_closing):
+                            body = (
+                                f"{prefix}{character * opening_length}\n"
+                                f"{prefix}[[fake]]\n"
+                                f"{prefix}{character * (opening_length + extra_closing)}\n\n"
+                                "[[real]]"
+                            )
+                            self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_pre_and_comment_blocks_are_ignored(self):
+        body = (
+            "<pre>\n[[pre-code]]\n</pre>\n\n"
+            "<!--\n[[comment]]\n-->\n\n"
+            "[[real]]"
+        )
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_inline_html_comments_are_ignored(self):
+        body = "before <!-- [[comment]] --> [[real]]"
+        self.assertEqual(["real"], wiki_markdown.extract_wikilinks(body))
+
+    def test_single_line_html_blocks_and_comments_hide_only_their_own_line(self):
+        body = (
+            "<pre>[[pre-hidden]]</pre>\n"
+            "<!-- [[comment-hidden]] -->\n"
+            "[[visible]]"
+        )
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_all_pre_like_html_blocks_hide_wikilinks_until_their_close(self):
+        for tag in ("pre", "script", "style", "textarea"):
+            with self.subTest(tag=tag):
+                body = f"<{tag}>\n[[hidden]]\n</{tag.upper()}>\n[[visible]]"
+                self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_block_markers_inside_pre_like_html_are_literal(self):
+        body = "<pre>\n- [[hidden-list]]\n> [[hidden-quote]]\n</pre>\n[[visible]]"
+        self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_unclosed_html_block_ends_when_its_blockquote_container_ends(self):
+        body = "> <script>\n> [[script-hidden]]\n\n[[outside]]"
+        self.assertEqual(["outside"], wiki_markdown.extract_wikilinks(body))
+
+    def test_blank_terminated_commonmark_html_blocks_hide_wikilinks(self):
+        bodies = (
+            "<div>\n[[hidden]]\n</div>\n\n[[visible]]",
+            "<custom-element data-value='x'>\n[[hidden]]\n\n[[visible]]",
+        )
+        for body in bodies:
+            with self.subTest(body=body):
+                self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_processing_instruction_declaration_and_cdata_blocks_are_literal(self):
+        bodies = (
+            "<?target\n[[hidden]]\n?>\n[[visible]]",
+            "<!DECLARATION\n[[hidden]]\n>\n[[visible]]",
+            "<![CDATA[\n[[hidden]]\n]]>\n[[visible]]",
+        )
+        for body in bodies:
+            with self.subTest(body=body):
+                self.assertEqual(["visible"], wiki_markdown.extract_wikilinks(body))
+
+    def test_crlf_input_preserves_links_outside_code(self):
+        body = "[[before]]\r\n~~~\r\n[[hidden]]\r\n~~~\r\n[[after]]\r\n"
+        self.assertEqual(
+            ["before", "after"],
+            wiki_markdown.extract_wikilinks(body),
+        )
+
+
+class SharedImplementationTests(unittest.TestCase):
+    """One parser and one corpus definition, imported rather than re-declared."""
+
+    TOOLS = (wiki_lint, wiki_search, wiki_graph_extract, wiki_graph_lint, wiki_stats)
+
+    def test_all_tools_share_the_same_extractor(self):
+        # Each script used to carry its own WIKILINK_RE, so a fix to one left
+        # the other four reporting different links for the same page.
+        for module in self.TOOLS:
+            with self.subTest(module=module.__name__):
+                self.assertIs(wiki_markdown.extract_wikilinks, module.extract_wikilinks)
+
+    def test_all_tools_share_one_exclusion_set(self):
+        # The five copies had already diverged: only wiki_search.py knew about
+        # .wiki-cache. A page one tool indexes and another ignores is a silent
+        # inconsistency, and it surfaces far from its cause.
+        for module in self.TOOLS:
+            with self.subTest(module=module.__name__):
+                self.assertIs(wiki_markdown.SKIP_TOP_LEVEL_DIRS, module.SKIP_TOP_LEVEL_DIRS)
+
+    def test_excluded_directories_are_named_not_guessed(self):
+        self.assertEqual(
+            {"indexes", "graph", "raw", "Clippings", ".wiki-cache"},
+            set(wiki_markdown.SKIP_TOP_LEVEL_DIRS))
+
+    def test_clippings_are_scratch_input_not_pages(self):
+        # Saved web material lands in wiki/Clippings/ as raw input for ingest.
+        # Left in the corpus it is indexed and embedded like a curated page.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            (root / "concepts").mkdir(parents=True)
+            (root / "concepts" / "alpha.md").write_text(
+                "---\ntype: concept\ntitle: Alpha\n---\n\n# Alpha\n\nGamma.\n",
+                encoding="utf-8")
+            (root / "Clippings").mkdir(parents=True)
+            (root / "Clippings" / "saved.md").write_text(
+                "---\ntitle: Saved page\n---\n\n# Saved\n\nGamma delta epsilon.\n",
+                encoding="utf-8")
+
+            pages = wiki_search.collect_pages(root)
+
+            self.assertEqual(1, len(pages))
+            self.assertTrue(pages[0]["rel_path"].endswith("alpha.md"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/llm-wiki/tests/test_parse_cache.py
+++ b/skills/llm-wiki/tests/test_parse_cache.py
@@ -1,0 +1,211 @@
+"""The parse cache and the vector index are shared artifacts, so their keys
+and hashes must not encode the machine that built them.
+
+Both halves are load-bearing once ``embeddings.sqlite`` is committed: a section
+is addressed by ``<rel_path>\x1f<index>`` and validated by a content hash, so a
+native path separator or a CRLF checkout makes every section of a fresh clone
+look new and triggers a full re-embed of the corpus.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import wiki_search  # noqa: E402
+
+
+PAGE = "---\ntype: concept\ntitle: Alpha\n---\n\n# Alpha\n\nGamma delta.\n\n## Beta\n\nEpsilon.\n"
+
+
+def build_wiki(root: Path, text: str = PAGE, newline: str = "\n") -> Path:
+    page = root / "concepts" / "alpha.md"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_bytes(text.replace("\n", newline).encode("utf-8"))
+    return page
+
+
+class PortableLocatorTests(unittest.TestCase):
+    """The committed vector index is keyed by locator, so it must be OS-neutral."""
+
+    def test_rel_path_is_posix_on_every_platform(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+
+            page = wiki_search.collect_pages(root)[0]
+
+            self.assertEqual("concepts/alpha.md", page["rel_path"])
+            self.assertNotIn("\\", page["rel_path"])
+
+    def test_section_locator_has_no_native_separators(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+
+            sections = wiki_search.collect_sections(wiki_search.collect_pages(root))
+
+            for section in sections:
+                with self.subTest(section=section["heading_path"]):
+                    self.assertTrue(
+                        wiki_search.section_locator(section).startswith("concepts/alpha.md"))
+                    self.assertNotIn("\\", wiki_search.section_locator(section))
+
+
+class NewlineNeutralIdentityTests(unittest.TestCase):
+    """A CRLF checkout and an LF checkout of one commit are the same corpus."""
+
+    def test_crlf_and_lf_checkouts_agree_on_every_content_hash(self):
+        with tempfile.TemporaryDirectory() as lf_dir, tempfile.TemporaryDirectory() as crlf_dir:
+            lf_root, crlf_root = Path(lf_dir) / "wiki", Path(crlf_dir) / "wiki"
+            build_wiki(lf_root, newline="\n")
+            build_wiki(crlf_root, newline="\r\n")
+
+            def hashes(root: Path) -> list[str]:
+                pages = wiki_search.collect_pages(root)
+                return [wiki_search.section_content_hash(section)
+                        for section in wiki_search.collect_sections(pages)]
+
+            self.assertEqual(hashes(lf_root), hashes(crlf_root))
+
+    def test_a_crlf_page_survives_the_cache_round_trip(self):
+        # The cache rebuilds a body by joining sections on "\n". Without
+        # normalization the reconstruction differs from the cold parse, so a
+        # warm run and a cold run disagree about the page they just indexed.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root, newline="\r\n")
+            cache = root / ".wiki-cache" / "search-index.json"
+
+            cold = wiki_search.collect_pages(root)
+            wiki_search.collect_pages(root, cache)
+            warm = wiki_search.collect_pages(root, cache)
+
+            self.assertEqual(cold[0]["body"].strip(), warm[0]["body"].strip())
+            self.assertNotIn("\r", warm[0]["body"])
+
+
+class ParseCacheRoundTripTests(unittest.TestCase):
+    @staticmethod
+    def state(pages: list[dict]) -> list[tuple]:
+        # Everything retrieval consumes must survive the round trip. `body` is a
+        # reconstruction, not a byte-exact copy, so it is compared stripped; the
+        # section text it is rebuilt from is compared verbatim. The leading
+        # newline it can gain comes from the empty preamble section the splitter
+        # emits for a page opening with a heading -- a separate defect, fixed
+        # where sections are split rather than papered over here.
+        return [
+            (p["slug"], p["rel_path"], p["meta"], p["links"],
+             [(s["heading_path"], s["level"], s["text"]) for s in p["sections"]],
+             p["body"].strip())
+            for p in pages
+        ]
+
+    def test_cached_run_matches_a_cold_run(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+
+            cold = wiki_search.collect_pages(root)
+            built = wiki_search.collect_pages(root, cache)
+            self.assertTrue(cache.exists())
+            warm = wiki_search.collect_pages(root, cache)
+
+            self.assertEqual(self.state(cold), self.state(built))
+            self.assertEqual(self.state(cold), self.state(warm))
+
+    def test_cache_keys_are_posix_so_another_os_can_reuse_them(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+            wiki_search.collect_pages(root, cache)
+
+            payload = json.loads(cache.read_text(encoding="utf-8"))
+
+            self.assertEqual(["concepts/alpha.md"], sorted(payload["files"]))
+
+    def test_cached_digest_is_of_the_normalized_text_not_the_raw_bytes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root, newline="\r\n")
+            cache = root / ".wiki-cache" / "search-index.json"
+            wiki_search.collect_pages(root, cache)
+
+            payload = json.loads(cache.read_text(encoding="utf-8"))
+
+            self.assertEqual(
+                hashlib.sha256(PAGE.encode("utf-8")).hexdigest(),
+                payload["files"]["concepts/alpha.md"]["sha256"],
+            )
+
+    def test_current_schema_cache_is_reused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+            wiki_search.collect_pages(root, cache)
+
+            payload = json.loads(cache.read_text(encoding="utf-8"))
+
+            self.assertEqual(wiki_search.PARSE_CACHE_SCHEMA, payload["schema"])
+            self.assertEqual(
+                [s["heading_path"] for s in wiki_search.collect_pages(root)[0]["sections"]],
+                [s["heading_path"] for s in wiki_search.collect_pages(root, cache)[0]["sections"]],
+            )
+
+    def test_cache_from_an_older_parser_is_discarded(self):
+        # Entries are keyed by file hash, so an unchanged page would keep
+        # serving output built by the previous parser. Only the schema version
+        # can catch that, which is why it must move with the representation.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            page = build_wiki(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+            digest = hashlib.sha256(page.read_bytes()).hexdigest()
+            cache.parent.mkdir(parents=True, exist_ok=True)
+            cache.write_text(json.dumps({
+                "schema": wiki_search.PARSE_CACHE_SCHEMA - 1,
+                "files": {"concepts/alpha.md": {
+                    "sha256": digest,
+                    "meta": {"type": "concept", "title": "Alpha"},
+                    "links": [],
+                    "sections": [{"heading_path": ["STALE"], "level": 1,
+                                  "text": "cached old parser output"}],
+                }},
+            }), encoding="utf-8")
+
+            pages = wiki_search.collect_pages(root, cache)
+
+            self.assertNotIn(
+                ["STALE"], [s["heading_path"] for s in pages[0]["sections"]])
+            self.assertNotIn("cached old parser output", pages[0]["body"])
+            self.assertEqual(
+                wiki_search.PARSE_CACHE_SCHEMA,
+                json.loads(cache.read_text(encoding="utf-8"))["schema"],
+            )
+
+    def test_edited_page_invalidates_its_cache_entry(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+            wiki_search.collect_pages(root, cache)
+
+            build_wiki(root, "---\ntype: concept\ntitle: Alpha\n---\n\n# Alpha\n\nRewritten omega.\n")
+            reparsed = wiki_search.collect_pages(root, cache)
+
+            self.assertIn("Rewritten omega.", reparsed[0]["body"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/llm-wiki/tests/test_provenance_dedup.py
+++ b/skills/llm-wiki/tests/test_provenance_dedup.py
@@ -1,0 +1,196 @@
+"""Several curated pages may legitimately derive from one source document.
+
+The rule is therefore not "one result per source". It is narrower: a `source`
+page is worth showing only when nothing derived from the same source matched.
+Collapsing further would hide distinct concepts that happen to share a
+citation, which is the common case in a wiki built from one document set.
+
+Page and section granularity implement the same rule differently, and both are
+tested here: a page-level score can be transferred to the page that replaces
+it, while a section's fused score cannot be handed to a different page's
+section, so section granularity only suppresses.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import wiki_search  # noqa: E402
+
+
+def page(slug: str, page_type: str, source: str = "docs/shared.md") -> dict:
+    return {"slug": slug, "meta": {"type": page_type, "sources": [source]}}
+
+
+class ProvenanceKeyTests(unittest.TestCase):
+    def test_pages_citing_one_document_share_a_key(self):
+        self.assertEqual(
+            wiki_search.primary_provenance(page("a", "concept")),
+            wiki_search.primary_provenance(page("b", "concept")),
+        )
+
+    def test_the_key_is_separator_and_case_insensitive(self):
+        self.assertEqual(
+            wiki_search.primary_provenance(page("a", "concept", "Docs\\Shared.md")),
+            wiki_search.primary_provenance(page("b", "concept", "docs/shared.md")),
+        )
+
+    def test_a_page_citing_nothing_is_its_own_group(self):
+        uncited = {"slug": "lonely", "meta": {"type": "concept"}}
+
+        self.assertEqual("page:lonely", wiki_search.primary_provenance(uncited))
+
+
+class PageGranularityCollapseTests(unittest.TestCase):
+    def test_distinct_concepts_with_same_source_are_preserved(self):
+        scored = [(10.0, page("concept-a", "concept")), (9.0, page("concept-b", "concept"))]
+
+        result = wiki_search.collapse_by_provenance(scored, "concept")
+
+        self.assertEqual(["concept-a", "concept-b"], [p["slug"] for _, p in result])
+
+    def test_source_variant_is_hidden_when_derived_page_exists(self):
+        scored = [(10.0, page("raw-source", "source")), (8.0, page("derived", "concept"))]
+
+        result = wiki_search.collapse_by_provenance(scored, "concept")
+
+        self.assertEqual(["derived"], [p["slug"] for _, p in result])
+        self.assertEqual(10.0, result[0][0])
+
+    def test_source_score_is_transferred_without_collapsing_derived_pages(self):
+        # Only the hidden source's score moves, and only to one representative.
+        scored = [
+            (100.0, page("raw-source", "source")),
+            (2.0, page("concept-a", "concept")),
+            (1.0, page("concept-b", "concept")),
+        ]
+
+        result = wiki_search.collapse_by_provenance(scored, "concept")
+
+        self.assertEqual([(100.0, "concept-a"), (1.0, "concept-b")],
+                         [(score, p["slug"]) for score, p in result])
+
+    def test_preferred_type_becomes_provenance_representative(self):
+        scored = [
+            (20.0, page("raw-source", "source")),
+            (8.0, page("api-page", "api")),
+            (3.0, page("concept-page", "concept")),
+        ]
+
+        result = wiki_search.collapse_by_provenance(scored, "concept")
+
+        self.assertEqual([(20.0, "concept-page"), (8.0, "api-page")],
+                         [(score, p["slug"]) for score, p in result])
+
+    def test_best_source_is_kept_when_group_has_only_sources(self):
+        scored = [(7.0, page("source-a", "source")), (9.0, page("source-b", "source"))]
+
+        result = wiki_search.collapse_by_provenance(scored, None)
+
+        self.assertEqual(["source-b"], [p["slug"] for _, p in result])
+
+    def test_preference_does_not_copy_score_between_derived_pages(self):
+        # With no source in the group there is nothing to transfer; preference
+        # reorders, it does not invent a score.
+        scored = [(9.0, page("api-page", "api")), (1.0, page("concept-page", "concept"))]
+
+        result = wiki_search.collapse_by_provenance(scored, "concept")
+
+        self.assertEqual([(9.0, "api-page"), (1.0, "concept-page")],
+                         [(score, p["slug"]) for score, p in result])
+
+    def test_lower_scoring_source_does_not_inflate_preferred_page(self):
+        scored = [
+            (9.0, page("api-page", "api")),
+            (2.0, page("raw-source", "source")),
+            (1.0, page("concept-page", "concept")),
+        ]
+
+        result = wiki_search.collapse_by_provenance(scored, "concept")
+
+        self.assertEqual([(9.0, "api-page"), (2.0, "concept-page")],
+                         [(score, p["slug"]) for score, p in result])
+
+
+class SectionGranularitySuppressionTests(unittest.TestCase):
+    @staticmethod
+    def located(*pages: dict) -> list[dict]:
+        return [{**p, "rel_path": f"{p['slug']}.md"} for p in pages]
+
+    def test_a_lone_source_page_is_kept(self):
+        # Nothing derived from this document matched, so the source page is the
+        # only evidence there is.
+        matched = self.located(page("raw", "source"))
+
+        self.assertEqual(set(), wiki_search.suppressed_source_pages(matched))
+
+    def test_a_source_page_is_suppressed_once_something_derived_matched(self):
+        matched = self.located(page("raw", "source"), page("derived", "concept"))
+
+        self.assertEqual({"raw.md"}, wiki_search.suppressed_source_pages(matched))
+
+    def test_suppression_does_not_cross_provenance_groups(self):
+        pages = [
+            {**page("raw-x", "source", "docs/x.md"), "rel_path": "sources/raw-x.md"},
+            {**page("derived-x", "concept", "docs/x.md"), "rel_path": "concepts/derived-x.md"},
+            {**page("raw-y", "source", "docs/y.md"), "rel_path": "sources/raw-y.md"},
+        ]
+
+        self.assertEqual({"sources/raw-x.md"}, wiki_search.suppressed_source_pages(pages))
+
+
+class DedupCliTests(unittest.TestCase):
+    def build_wiki(self, root: Path) -> None:
+        for kind, slug, body in (
+            ("sources", "raw-alpha", "Gamma delta epsilon."),
+            ("concepts", "alpha-idea", "Gamma delta epsilon."),
+        ):
+            directory = root / kind
+            directory.mkdir(parents=True, exist_ok=True)
+            page_type = "source" if kind == "sources" else "concept"
+            (directory / f"{slug}.md").write_text(
+                f"---\ntype: {page_type}\ntitle: {slug}\nsources: [docs/alpha.md]\n---\n\n"
+                f"# {slug}\n\n{body}\n",
+                encoding="utf-8",
+            )
+
+    def search(self, root: Path, *extra: str) -> list[dict]:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPTS / "wiki_search.py"), "gamma", *extra,
+             "--wiki", str(root), "--json", "--no-embed"],
+            capture_output=True, text=True, encoding="utf-8",
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        return json.loads(result.stdout)["results"]
+
+    def test_the_source_page_is_hidden_behind_its_derived_concept(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            self.build_wiki(root)
+
+            self.assertEqual({"raw-alpha", "alpha-idea"},
+                             {row["slug"] for row in self.search(root)})
+            self.assertEqual({"alpha-idea"},
+                             {row["slug"] for row in self.search(root, "--dedup-provenance")})
+
+    def test_page_granularity_applies_the_same_rule(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            self.build_wiki(root)
+
+            rows = self.search(root, "--dedup-provenance", "--granularity", "page")
+
+            self.assertEqual(["alpha-idea"], [row["slug"] for row in rows])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/llm-wiki/tests/test_sections.py
+++ b/skills/llm-wiki/tests/test_sections.py
@@ -1,0 +1,160 @@
+"""Sections are the retrieval unit, so their boundaries are a contract.
+
+A wrong boundary is not a cosmetic problem: each section becomes a BM25 unit,
+a section locator in the JSON evidence, and one embedded vector. A heading
+invented inside a code block, or a heading whose text is silently truncated,
+is indexed and retrieved exactly like a real one.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import wiki_markdown  # noqa: E402
+import wiki_search  # noqa: E402
+
+
+class SectionSplitTests(unittest.TestCase):
+    def headings(self, body: str) -> list[list[str]]:
+        return [section["heading_path"] for section in wiki_search.split_sections("T", body)]
+
+    # -- code blocks are not headings ------------------------------------
+
+    def test_headings_inside_code_fences_do_not_split(self):
+        body = "# A\n\n```\n# not a heading\n```\n\ntail\n"
+        sections = wiki_search.split_sections("T", body)
+
+        self.assertEqual(1, len(sections))
+        self.assertIn("# not a heading", sections[0]["text"])
+
+    def test_a_tilde_run_does_not_close_a_backtick_fence(self):
+        body = "# A\n```\ncode\n~~~\n# FAKE\n```\ntail\n"
+        self.assertEqual([["A"]], self.headings(body))
+
+    def test_a_shorter_run_does_not_close_a_longer_fence(self):
+        body = "# A\n````\ncode\n```\n# FAKE\n````\ntail\n"
+        self.assertEqual([["A"]], self.headings(body))
+
+    def test_a_closing_fence_may_not_carry_trailing_text(self):
+        body = "# A\n```\ncode\n``` tail\n# FAKE\n"
+        self.assertEqual([["A"]], self.headings(body))
+
+    def test_info_string_opens_but_does_not_close(self):
+        body = "# A\n```python\n# FAKE\n```\n\n## REAL\n\nx\n"
+        self.assertEqual([["A"], ["A", "REAL"]], self.headings(body))
+
+    def test_four_spaces_is_indented_code_not_a_heading(self):
+        body = "# A\n\ntext\n\n    ## FAKE\n\nbody\n"
+        self.assertEqual([["A"]], self.headings(body))
+
+    def test_splitter_and_link_extractor_agree_on_fences(self):
+        # Both must consult the same CommonMark state machine; a local fence
+        # toggle in either one drifts from the other, and the drift is invisible
+        # until a page indexes differently than it links.
+        body = "# A\n````\n[[fake-link]]\n```\n# FAKE\n````\n\n## REAL\n\n[[real-link]]\n"
+        self.assertEqual([["A"], ["A", "REAL"]], self.headings(body))
+        self.assertEqual(["real-link"], wiki_markdown.extract_wikilinks(body))
+
+    # -- what an ATX heading is ------------------------------------------
+
+    def test_up_to_three_spaces_still_marks_a_heading(self):
+        body = "# A\n\ntext\n\n   ## REAL\n\nbody\n"
+        self.assertEqual([["A"], ["A", "REAL"]], self.headings(body))
+
+    def test_a_hash_run_with_no_space_is_not_a_heading(self):
+        self.assertEqual([[]], self.headings("#no-space\n\nbody\n"))
+
+    def test_a_literal_trailing_hash_is_part_of_the_heading(self):
+        # CommonMark reads a hash run as a closing sequence only when whitespace
+        # precedes it. `C#` and `F#` are language names, and truncating them to
+        # `C` and `F` corrupts the heading path, the searchable text and the
+        # embedded vector for that section.
+        self.assertEqual([["C#"]], self.headings("# C#\n\nbody\n"))
+        self.assertEqual([["F##"]], self.headings("# F##\n\nbody\n"))
+        self.assertEqual([["Title###"]], self.headings("# Title###\n\nbody\n"))
+
+    def test_a_spaced_trailing_hash_run_is_a_closing_sequence(self):
+        self.assertEqual([["Title"]], self.headings("# Title ###\n\nbody\n"))
+        self.assertEqual([["Title"]], self.headings("# Title #\t\n\nbody\n"))
+
+    def test_an_escaped_hash_run_does_not_close_the_heading(self):
+        # CommonMark: `### foo \###` keeps the hashes as content. The backslash
+        # survives because sections store raw Markdown; tokenization drops it,
+        # so only the heading path shows it.
+        self.assertEqual([["foo \\###"]], self.headings("# foo \\###\n\nbody\n"))
+        self.assertEqual([["foo #\\##"]], self.headings("# foo #\\##\n\nbody\n"))
+
+    def test_an_empty_atx_heading_splits_without_naming_the_section(self):
+        # `##` alone is a valid empty heading, so it is a boundary and it holds
+        # its level for the headings below it -- but it contributes no name, and
+        # padding the path with "" would put an empty token into every child
+        # path and every searchable string.
+        sections = wiki_search.split_sections("T", "# A\n\nx\n\n##\n\ny\n\n### C\n\nz\n")
+
+        self.assertEqual([["A"], ["A"], ["A", "C"]], [s["heading_path"] for s in sections])
+        self.assertEqual([1, 2, 3], [s["level"] for s in sections])
+        self.assertIn("y", sections[1]["text"])
+
+    # -- sections that carry nothing are not sections ---------------------
+
+    def test_empty_preamble_before_the_first_heading_is_dropped(self):
+        # A page opening with a heading used to emit an empty section ahead of
+        # it. Empty sections are scored, embedded, and can take the top slot
+        # with an empty snippet while consuming a --per-page slot that a real
+        # passage needed.
+        sections = wiki_search.split_sections("T", "# Title\n\nBody text.\n")
+
+        self.assertEqual(1, len(sections))
+        self.assertEqual(["Title"], sections[0]["heading_path"])
+        self.assertEqual(0, sections[0]["section_index"])
+
+    def test_a_real_preamble_is_kept(self):
+        sections = wiki_search.split_sections("T", "Lead paragraph.\n\n# Title\n\nBody.\n")
+
+        self.assertEqual(2, len(sections))
+        self.assertEqual([], sections[0]["heading_path"])
+        self.assertIn("Lead paragraph.", sections[0]["text"])
+
+    def test_an_empty_heading_with_no_body_is_dropped(self):
+        # An inherited path is not a name: the section says nothing its parent
+        # does not already say, so it is worth neither a slot nor a vector.
+        self.assertEqual([["A"]], self.headings("# A\n\nx\n\n##\n"))
+
+    def test_section_indexes_stay_contiguous_after_dropping(self):
+        # section_index is half of the vector-index locator, so a gap would
+        # address a section that does not exist.
+        sections = wiki_search.split_sections("T", "# A\n\nx\n\n## B\n\ny\n")
+
+        self.assertEqual([0, 1], [section["section_index"] for section in sections])
+
+
+class SectionCacheRoundTripTests(unittest.TestCase):
+    """With no empty preamble, a cached body reproduces the cold parse exactly."""
+
+    def test_a_cached_body_no_longer_gains_a_leading_blank_line(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            (root / "concepts").mkdir(parents=True)
+            (root / "concepts" / "alpha.md").write_text(
+                "---\ntitle: Alpha\n---\n\n# Alpha\n\nGamma delta.\n\n## Beta\n\nEpsilon.\n",
+                encoding="utf-8")
+            cache = root / ".wiki-cache" / "search-index.json"
+
+            cold = wiki_search.collect_pages(root)
+            wiki_search.collect_pages(root, cache)
+            warm = wiki_search.collect_pages(root, cache)
+
+            self.assertEqual(cold[0]["body"].rstrip(), warm[0]["body"].rstrip())
+            self.assertFalse(warm[0]["body"].startswith("\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/llm-wiki/tests/test_setup_contract.py
+++ b/skills/llm-wiki/tests/test_setup_contract.py
@@ -1,0 +1,246 @@
+"""`"status": "ready"` is a promise about the files setup was asked to build,
+and `{"status": "error"}` is a promise that holds when it could not.
+
+Setup and search have deliberately different contracts around the parse cache.
+A search writes it best-effort -- results are already computed by then, so a
+lost race must not fail the query. Setup is asked to *produce* it, so the same
+outcome is a failure.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import setup_wiki  # noqa: E402
+import wiki_search  # noqa: E402
+
+
+def build_wiki(root: Path) -> None:
+    (root / "concepts").mkdir(parents=True)
+    (root / "concepts" / "alpha.md").write_text(
+        "---\ntype: concept\ntitle: Alpha\n---\n\n# Alpha\n\nGamma delta.\n",
+        encoding="utf-8",
+    )
+
+
+class ParseCacheLoaderTests(unittest.TestCase):
+    def test_loader_separates_an_unusable_cache_from_an_empty_one(self):
+        # `None` means "do not trust this file"; `{}` means "trusted, and it
+        # describes zero pages". A caller that cannot tell them apart either
+        # reuses entries from an older parser or rejects a brand-new wiki.
+        with tempfile.TemporaryDirectory() as directory:
+            cache = Path(directory) / "search-index.json"
+
+            self.assertIsNone(wiki_search.load_parse_cache(cache))
+
+            cache.write_text("{not json", encoding="utf-8")
+            self.assertIsNone(wiki_search.load_parse_cache(cache))
+
+            cache.write_text(json.dumps(
+                {"schema": wiki_search.PARSE_CACHE_SCHEMA - 1, "files": {}}), encoding="utf-8")
+            self.assertIsNone(wiki_search.load_parse_cache(cache))
+
+            cache.write_text(json.dumps(
+                {"schema": wiki_search.PARSE_CACHE_SCHEMA,
+                 "files": {"a.md": {"sha256": 1}}}), encoding="utf-8")
+            self.assertIsNone(wiki_search.load_parse_cache(cache))
+
+            cache.write_text(json.dumps(
+                {"schema": wiki_search.PARSE_CACHE_SCHEMA, "files": {}}), encoding="utf-8")
+            self.assertEqual({}, wiki_search.load_parse_cache(cache))
+
+    def test_a_search_still_treats_every_unusable_cache_as_no_cache(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+            cache.parent.mkdir(parents=True)
+            cache.write_text("{not json", encoding="utf-8")
+
+            self.assertEqual(1, len(wiki_search.collect_pages(root, cache)))
+
+
+class SetupReadinessTests(unittest.TestCase):
+    def test_a_cache_that_was_not_written_is_not_ready(self):
+        # Reproduced with an unwritable cache path: `cache: not written
+        # (WinError 183)` was followed by `"status": "ready"` and exit 0,
+        # because readiness only checked the vector count.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+            pages = wiki_search.collect_pages(root)
+
+            with self.assertRaises(RuntimeError) as caught:
+                setup_wiki.verify_parse_cache(root / ".wiki-cache" / "missing.json", pages)
+
+            self.assertIn("not written", str(caught.exception))
+
+    def test_a_cache_from_an_older_parser_is_not_ready(self):
+        # Verification goes through load_parse_cache(), the same loader a search
+        # uses, so it checks the schema and the per-entry shape rather than the
+        # existence of a file.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+            pages = wiki_search.collect_pages(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+            cache.parent.mkdir(parents=True, exist_ok=True)
+            cache.write_text(
+                json.dumps({"schema": wiki_search.PARSE_CACHE_SCHEMA - 1, "files": {}}),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(RuntimeError) as caught:
+                setup_wiki.verify_parse_cache(cache, pages)
+
+            self.assertIn("unusable", str(caught.exception))
+
+    def test_a_partial_cache_is_not_ready(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+            pages = wiki_search.collect_pages(root, cache)
+            pages = pages + [{"rel_path": "concepts/beta.md"}]
+
+            with self.assertRaises(RuntimeError) as caught:
+                setup_wiki.verify_parse_cache(cache, pages)
+
+            self.assertIn("incomplete", str(caught.exception))
+
+    def test_a_complete_cache_passes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+            cache = root / ".wiki-cache" / "search-index.json"
+            pages = wiki_search.collect_pages(root, cache)
+
+            setup_wiki.verify_parse_cache(cache, pages)  # must not raise
+
+    def test_a_freshly_initialized_wiki_has_a_valid_empty_cache(self):
+        # The state every `/wiki:init` leaves behind: the scaffold exists, but
+        # SCHEMA.md, index.md, log.md and dotfiles are all excluded from the
+        # corpus and nothing has been ingested yet. An empty file map is a
+        # correct cache here, not a corrupt one -- rejecting it would fail setup
+        # for every new wiki before its first ingest.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            root.mkdir(parents=True)
+            (root / "SCHEMA.md").write_text("# Schema\n", encoding="utf-8")
+            (root / "index.md").write_text("# Index\n", encoding="utf-8")
+            (root / "log.md").write_text("# Log\n", encoding="utf-8")
+            (root / ".page-template.md").write_text("# Template\n", encoding="utf-8")
+            cache = root / ".wiki-cache" / "search-index.json"
+
+            pages = wiki_search.collect_pages(root, cache)
+
+            self.assertEqual([], pages)
+            self.assertEqual({}, json.loads(cache.read_text(encoding="utf-8"))["files"])
+            setup_wiki.verify_parse_cache(cache, pages)  # must not raise
+
+    def test_setup_cli_on_an_empty_wiki_does_not_blame_the_parse_cache(self):
+        # End to end through the CLI: the semantic backend may or may not be
+        # installed in the test environment, but neither outcome may be reported
+        # as a cache problem, and stdout must stay parseable either way.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            root.mkdir(parents=True)
+            (root / "SCHEMA.md").write_text("# Schema\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPTS / "setup_wiki.py"), "--wiki", str(root), "--cache"],
+                capture_output=True, text=True, encoding="utf-8",
+            )
+            payload = json.loads(result.stdout)
+
+            self.assertNotIn("Traceback", result.stderr)
+            self.assertNotIn("cache", payload.get("error", ""))
+            if payload["status"] == "ready":
+                self.assertEqual(0, result.returncode)
+                self.assertEqual(0, payload["sections"])
+
+
+class SetupErrorEnvelopeTests(unittest.TestCase):
+    """A failed setup still owes the caller a parseable envelope."""
+
+    def run_main(self, root: Path, failure: BaseException):
+        stdout = io.StringIO()
+        argv = ["setup_wiki.py", "--wiki", str(root), "--cache"]
+
+        def explode(*_args, **_kwargs):
+            raise failure
+
+        with mock.patch.object(wiki_search, "load_local_embedding_backend", explode), \
+                mock.patch.object(sys, "argv", argv), \
+                contextlib.redirect_stdout(stdout):
+            with self.assertRaises(BaseException) as caught:
+                setup_wiki.main()
+        return caught.exception, stdout.getvalue()
+
+    def test_a_backend_failure_becomes_an_envelope_not_a_traceback(self):
+        # Reproduced by occupying the embeddings.sqlite path with a directory.
+        # sqlite3.OperationalError is not a RuntimeError, so catching only
+        # RuntimeError let it escape as a traceback with no JSON on stdout.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+
+            error, stdout = self.run_main(
+                root, sqlite3.OperationalError("unable to open database file"))
+            payload = json.loads(stdout)
+
+            self.assertIsInstance(error, SystemExit)
+            self.assertEqual(1, error.code)
+            self.assertEqual("error", payload["status"])
+            self.assertIn("OperationalError", payload["error"])
+            self.assertIn("unable to open database file", payload["error"])
+
+    def test_an_os_error_is_also_reported_structurally(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+
+            _, stdout = self.run_main(root, OSError("disk is full"))
+
+            self.assertIn("OSError", json.loads(stdout)["error"])
+
+    def test_a_runtime_error_keeps_its_bare_message(self):
+        # The tool's own diagnostics are already written for a human, so they
+        # are not prefixed with a type name the way a third-party failure is.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+
+            _, stdout = self.run_main(root, RuntimeError("semantic dependencies are missing"))
+
+            self.assertEqual("semantic dependencies are missing",
+                             json.loads(stdout)["error"])
+
+    def test_an_interrupt_is_not_swallowed(self):
+        # Ctrl-C and explicit exits are not failures to report; `Exception`
+        # deliberately does not cover them.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "wiki"
+            build_wiki(root)
+
+            error, stdout = self.run_main(root, KeyboardInterrupt())
+
+            self.assertIsInstance(error, KeyboardInterrupt)
+            self.assertEqual("", stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/llm-wiki/tests/test_tracked_index.py
+++ b/skills/llm-wiki/tests/test_tracked_index.py
@@ -1,0 +1,196 @@
+"""The vector index is only worth building if git will let you commit it.
+
+Every assertion here goes through `git check-ignore` against a real repository
+rather than reading a .gitignore, because that is the only honest check: the
+rule can live in the wiki's own file, the repository root's, or a global
+excludes file, and only git knows which one wins.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import init_wiki  # noqa: E402
+
+
+def git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+
+
+def init_repo(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    git(root, "init", "-q")
+
+
+def is_ignored(root: Path, relative: str) -> bool:
+    return git(root, "check-ignore", "-q", "--", relative).returncode == 0
+
+
+def rules(path: Path) -> list[str]:
+    return [line.strip() for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.strip().startswith("#")]
+
+
+def scaffold(root: Path, upgrade: bool = False) -> str:
+    """Run init_wiki() with the runtime install stubbed out."""
+    output: list[str] = []
+    with mock.patch.object(init_wiki, "install_runtime", lambda wiki: None), \
+            mock.patch("builtins.print", lambda *a, **k: output.append(
+                " ".join(str(part) for part in a))):
+        init_wiki.init_wiki(root, "wiki", "raw", upgrade=upgrade)
+    return "\n".join(output)
+
+
+class TemplatePolicyTests(unittest.TestCase):
+    def test_a_fresh_init_leaves_the_index_trackable(self):
+        # The template shipped `*` + `!.gitignore`, which was right while
+        # everything under .wiki-cache/ was disposable and wrong the moment the
+        # vector index became a tracked artifact: a fresh init built the index
+        # and then hid it, so `git add` refused it without -f.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "project"
+            init_repo(root)
+
+            scaffold(root)
+            (root / "wiki" / ".wiki-cache" / "embeddings.sqlite").write_bytes(b"x")
+
+            self.assertFalse(is_ignored(root, "wiki/.wiki-cache/embeddings.sqlite"))
+            # The parse cache stays ignored: it rebuilds in seconds and churns.
+            self.assertTrue(is_ignored(root, "wiki/.wiki-cache/search-index.json"))
+            self.assertEqual(
+                0, git(root, "add", "wiki/.wiki-cache/embeddings.sqlite").returncode)
+
+
+class LegacyIgnoreMigrationTests(unittest.TestCase):
+    """copy_template() cannot fix a file that already exists, so this can."""
+
+    def legacy(self, root: Path) -> Path:
+        cache_ignore = root / "wiki" / ".wiki-cache" / ".gitignore"
+        cache_ignore.parent.mkdir(parents=True)
+        cache_ignore.write_text("*\n!.gitignore\n", encoding="utf-8")
+        return cache_ignore
+
+    def test_upgrade_migrates_the_legacy_rule_set(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "project"
+            init_repo(root)
+            cache_ignore = self.legacy(root)
+
+            scaffold(root, upgrade=True)
+
+            self.assertEqual(["*", "!.gitignore", "!embeddings.sqlite"],
+                             rules(cache_ignore))
+            self.assertFalse(is_ignored(root, "wiki/.wiki-cache/embeddings.sqlite"))
+
+    def test_migration_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "project"
+            init_repo(root)
+            cache_ignore = self.legacy(root)
+
+            scaffold(root, upgrade=True)
+            once = cache_ignore.read_text(encoding="utf-8")
+            scaffold(root, upgrade=True)
+
+            self.assertEqual(once, cache_ignore.read_text(encoding="utf-8"))
+
+    def test_a_customized_ignore_file_is_reported_not_rewritten(self):
+        # An idempotent upgrade must not edit a file the user has touched, so
+        # the blocker is reported with the exact line to add instead.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "project"
+            init_repo(root)
+            cache_ignore = root / "wiki" / ".wiki-cache" / ".gitignore"
+            cache_ignore.parent.mkdir(parents=True)
+            original = "*\n!.gitignore\n!my-own-artifact.bin\n"
+            cache_ignore.write_text(original, encoding="utf-8")
+
+            with self.assertRaises(SystemExit):
+                scaffold(root, upgrade=True)
+
+            self.assertEqual(original, cache_ignore.read_text(encoding="utf-8"))
+            self.assertEqual("custom", init_wiki.migrate_wiki_cache_gitignore(cache_ignore))
+
+    def test_an_absent_file_is_left_to_the_template(self):
+        with tempfile.TemporaryDirectory() as directory:
+            missing = Path(directory) / "wiki" / ".wiki-cache" / ".gitignore"
+
+            self.assertEqual("absent", init_wiki.migrate_wiki_cache_gitignore(missing))
+
+
+class IgnoreRuleDetectionTests(unittest.TestCase):
+    def test_a_deeper_negation_beats_a_root_pattern(self):
+        # A root `*.sqlite` is not a blocker: rules in a deeper directory win,
+        # so the template's own negation rescues the index without help. This is
+        # also why `check-ignore -v` cannot carry the verdict -- it exits 0 for a
+        # path matching a *negated* pattern too, and would report
+        # `!embeddings.sqlite` as the rule hiding the index.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "project"
+            init_repo(root)
+            (root / ".gitignore").write_text("*.sqlite\n", encoding="utf-8")
+
+            output = scaffold(root)
+
+            self.assertNotIn("git-ignored", output)
+            self.assertFalse(is_ignored(root, "wiki/.wiki-cache/embeddings.sqlite"))
+
+    def test_an_excluded_parent_directory_is_detected_and_named(self):
+        # The one shape the negation cannot fix: git never descends into an
+        # excluded directory, so `!embeddings.sqlite` inside it is dead text.
+        # The rule also lives outside the wiki, which is why the check asks git
+        # instead of reading .wiki-cache/.gitignore.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "project"
+            init_repo(root)
+            (root / ".gitignore").write_text(".wiki-cache/\n", encoding="utf-8")
+
+            rule = init_wiki.index_ignore_rule(
+                root, root / "wiki" / ".wiki-cache" / "embeddings.sqlite")
+
+            self.assertIsNotNone(rule)
+            self.assertIn(".wiki-cache/", rule)
+
+    def test_a_directory_outside_git_is_not_treated_as_blocked(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "project"
+            root.mkdir(parents=True)
+
+            self.assertIsNone(init_wiki.index_ignore_rule(
+                root, root / "wiki" / ".wiki-cache" / "embeddings.sqlite"))
+
+            output = scaffold(root)
+            self.assertNotIn("git-ignored", output)
+
+
+class BlockedIndexCliTests(unittest.TestCase):
+    def test_a_blocked_index_fails_before_the_runtime_install(self):
+        # Delivering this news after a full embed pass would waste the pass, so
+        # the check runs first and is fatal.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "project"
+            init_repo(root)
+            (root / ".gitignore").write_text(".wiki-cache/\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPTS / "init_wiki.py"), ".", "--upgrade"],
+                cwd=root, capture_output=True, text=True, encoding="utf-8",
+            )
+
+            self.assertEqual(1, result.returncode)
+            self.assertIn("Blocked", result.stderr)
+            self.assertIn("excluded", result.stderr)
+            self.assertNotIn("Installing", result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> Stacked on #9 through #17. The commit under review is the tip.

`--json` is a consumer contract: a rounded fused score, the retriever list, and
only what survived provenance dedup, `--per-page` and `--top`. Nothing in it
can answer "why did this section rank here". The raw BM25 score, the two
channel ranks and the cosine distance exist nowhere else, and candidates cut by
the page limit never appear in that envelope at all - so the RRF behaviour the
docs describe is not reproducible from any shipped command.

`--debug-ranking` prints the full fused order and annotates each candidate with
the limit that removed it (`dedup_provenance`, `per_page`, `top`), alongside
the corpus and per-channel hit counts. The loop that assigns those labels
mirrors the real selection loop in the same order, so the diagnostic cannot
drift from the behaviour it explains.

Two supporting changes:

`local_semantic_order()` returns `(locator, distance)` pairs. The cosine
distance is otherwise discarded, and it is not recomputable without loading the
model - it is the only way to show why a section did or did not clear
`MAX_COSINE_DISTANCE`.

The fusion parameters become `RRF_K`, `LEXICAL_CANDIDATE_LIMIT` and
`SEMANTIC_CANDIDATE_LIMIT` so the payload can report the values that produced
the numbers it prints. A diagnostic emitting scores the reader cannot tie back
to their parameters is a riddle, not an explanation.

When the semantic backend fails mid-query the recorded ranks and distances are
cleared, so the diagnostic never reports a channel that did not contribute to
the ranking. `--debug-ranking` is rejected at page granularity, where there is
no channel fusion to explain.

### Tests

4 cases: each limit named on the candidate it removed, dedup named before the
page limit, per-channel numbers surviving into the payload, and lexical mode
not passing a BM25 score off as a fused one.