### PR TITLE
fix(scripts): resolve path-qualified wikilinks instead of reporting them broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **Path-qualified wikilinks are now resolved instead of being reported broken.** `wiki_lint.py`, `wiki_graph_extract.py`, `wiki_search.py`, and `wiki_stats.py` each compared raw wikilink text against page slugs, where a slug is the bare filename stem — so `[[entities/kalman-filter]]`, a very common authoring form, matched nothing. The failures were silent and each misled differently: lint reported every such link as broken *and*, because inbound edges were keyed the same way, reported well-referenced pages as orphans; `wiki_graph_extract` emitted no `mentions` edge for them at all; `wiki_search --backlinks` missed them and `--top-linked` split one page's count across the bare and qualified forms; `wiki_stats` understated hubs. Measured on one 55-page wiki: 142 of 153 reported broken links were false, 15 of 16 orphans were false, and 126 of 308 mention edges were missing from the graph. Links are now normalized (display alias, heading anchor, `.md` suffix) before comparison. A directory prefix is treated as a **constraint**, not decoration — a qualified link resolves only if that exact path exists, with no fall back to a bare-stem match, because falling back would let `[[raw/foo]]` bind to `sources/foo.md`, a real collision wherever source pages are named after the raw file they summarize. `wiki_stats` is a documented exception: it counts popularity rather than adjudicating correctness, so it reduces to the stem and does not verify resolution.
+- Adds `skills/llm-wiki/scripts/test_link_resolution.py` — stdlib-only, no test framework, run directly. 43 cases across all four resolvers, including guard cases that fail if the path constraint is relaxed.
+
 ## [3.1.0] - 2026-09-03
 
 ### Changed

--- a/skills/llm-wiki/scripts/test_link_resolution.py
+++ b/skills/llm-wiki/scripts/test_link_resolution.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Regression tests for wikilink resolution.
+
+Stdlib only, no test framework — run it directly:
+
+    python3 skills/llm-wiki/scripts/test_link_resolution.py
+
+Exits 0 on success, 1 on any failure.
+
+Why this file exists
+--------------------
+`wiki_lint.py`, `wiki_graph_extract.py`, and `wiki_search.py` all compared raw
+wikilink text against page slugs, where a slug is the bare filename stem. Every
+path-qualified link — `[[entities/kalman-filter]]`, a very common form in real
+wikis — therefore matched nothing. The linter reported them all as broken, the
+graph extractor silently emitted no `mentions` edge for them, and `--backlinks`
+missed them. In one wiki of 55 pages that was 142 false "broken link" reports
+out of 153, plus 15 pages misreported as orphans.
+
+The fix normalizes before comparing. The subtle part, and the reason for the
+guard cases below, is that a directory prefix must be treated as a CONSTRAINT
+rather than stripped: naively reducing to the stem would make `[[raw/foo]]`
+resolve to `sources/foo.md`. That collision is not hypothetical — source pages
+are conventionally named after the raw file they summarize, so stem-stripping
+turns a genuinely broken out-of-tree link into a false pass.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import wiki_graph_extract  # noqa: E402
+import wiki_lint  # noqa: E402
+import wiki_search  # noqa: E402
+import wiki_stats  # noqa: E402
+
+
+# A wiki containing BOTH sources/<stem>.md and (out of tree) raw/<stem>.md,
+# which is the collision the path constraint exists to handle.
+BY_PATH = {
+    "sources/2024-01-15-field-notes": "2024-01-15-field-notes",
+    "entities/kalman-filter": "kalman-filter",
+    "concepts/battery-runtime": "battery-runtime",
+}
+BY_SLUG = {
+    "2024-01-15-field-notes",
+    "kalman-filter",
+    "battery-runtime",
+    "shannon-entropy",
+}
+
+RESOLVE_CASES = [
+    # (link, expected, why)
+    ("entities/kalman-filter", "kalman-filter", "path-qualified, path exists"),
+    ("shannon-entropy", "shannon-entropy", "bare stem, page exists"),
+    ("entities/kalman-filter#History", "kalman-filter", "heading anchor stripped"),
+    ("entities/kalman-filter.md", "kalman-filter", "explicit .md stripped"),
+    ("entities/kalman-filter|Kalman", "kalman-filter", "display alias stripped"),
+    ("  entities/kalman-filter  ", "kalman-filter", "surrounding whitespace"),
+    ("/entities/kalman-filter/", "kalman-filter", "stray leading/trailing slashes"),
+    ("Entities/Kalman-Filter", None,
+     "matching is case-SENSITIVE, symmetric with bare-slug matching"),
+    # --- guards: these must NOT resolve ---
+    ("raw/2024-01-15-field-notes", None,
+     "GUARD: out-of-tree path must not bind to the same-stem sources page"),
+    ("personas/kalman-filter", None,
+     "GUARD: wrong directory must not bind to entities/kalman-filter"),
+    ("nonexistent-page", None, "unknown bare stem"),
+    ("", None, "empty link"),
+    ("#anchor-only", None, "anchor with no page"),
+]
+
+STEM_CASES = [
+    ("entities/kalman-filter", "kalman-filter", "prefix dropped"),
+    ("kalman-filter", "kalman-filter", "bare stem unchanged"),
+    ("entities/kalman-filter#History", "kalman-filter", "anchor dropped"),
+    ("raw/whatever", "whatever", "out-of-tree link still counted by stem"),
+]
+
+
+def check(label, got, expected, why, failures):
+    ok = got == expected
+    if not ok:
+        failures.append(f"{label}: {why} -> got {got!r}, expected {expected!r}")
+    print(f"  {'PASS' if ok else 'FAIL'}  {label:<7} {str(got):<22} {why}")
+    return ok
+
+
+def main():
+    failures = []
+
+    resolvers = [
+        ("lint", wiki_lint.resolve_link),
+        ("graph", wiki_graph_extract.resolve_link_slug),
+        ("search", wiki_search.resolve_link),
+    ]
+    for label, fn in resolvers:
+        print(f"{label}: path-constrained resolution")
+        for link, expected, why in RESOLVE_CASES:
+            check(label, fn(link, BY_PATH, BY_SLUG), expected,
+                  f"[[{link}]] — {why}", failures)
+        print()
+
+    # wiki_stats counts popularity and deliberately does NOT verify resolution,
+    # so it reduces to the stem. Pin that documented difference so nobody
+    # "fixes" it into a correctness check by accident.
+    print("stats: stem-only counting (resolution deliberately NOT verified)")
+    for link, expected, why in STEM_CASES:
+        check("stats", wiki_stats.link_stem(link), expected,
+              f"[[{link}]] — {why}", failures)
+
+    total = len(RESOLVE_CASES) * len(resolvers) + len(STEM_CASES)
+    print(f"\n{total - len(failures)}/{total} passed")
+    if failures:
+        print("\nFAILURES:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/llm-wiki/scripts/wiki_graph_extract.py
+++ b/skills/llm-wiki/scripts/wiki_graph_extract.py
@@ -54,6 +54,35 @@ except ImportError:
 WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
+
+def clean_link_target(link: str) -> str:
+    """Strip a wikilink down to its path, dropping alias, anchor, and .md."""
+    target = link.split("|", 1)[0]      # drop a display alias, if any
+    target = target.split("#", 1)[0]    # drop a heading anchor
+    target = target.replace("\\", "/").strip().strip("/")
+    if target.lower().endswith(".md"):
+        target = target[:-3]
+    return target.strip()
+
+
+def resolve_link_slug(link: str, by_path: dict, by_slug) -> "str | None":
+    """Resolve a wikilink to the page slug it names, or None if unresolvable.
+
+    Node ids are keyed on the filename stem, so comparing raw link text drops
+    every path-qualified link ([[entities/kalman-filter]]) and its mentions edge
+    is simply never emitted. A directory prefix is treated as a CONSTRAINT: a
+    qualified link resolves only if that exact path exists, so [[raw/foo]]
+    cannot silently bind to sources/foo.md and fabricate an edge between two
+    different documents that happen to share a stem.
+    """
+    target = clean_link_target(link)
+    if not target:
+        return None
+    if "/" in target:
+        return by_path.get(target)
+    return target if target in by_slug else None
+
+
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "index.md", "log.md", "README.md"}
 SKIP_TOP_LEVEL_DIRS = {"indexes", "graph", "raw"}
 
@@ -223,6 +252,16 @@ def build_edges(pages: list[dict], slug_to_id: dict[str, str]) -> list[dict]:
     edges: list[dict] = []
     seen_ids: set[str] = set()
 
+    # Index for resolving path-qualified wikilinks: wiki-relative path without
+    # the .md suffix, lowercased, -> slug.
+    path_to_slug: dict[str, str] = {}
+    for p in pages:
+        rel = p["rel_path"].replace("\\", "/")
+        if rel.lower().endswith(".md"):
+            rel = rel[:-3]
+        path_to_slug[rel] = p["slug"]
+    known_slugs = set(slug_to_id.keys())
+
     def push(edge: dict) -> None:
         if edge["id"] in seen_ids:
             return
@@ -266,7 +305,7 @@ def build_edges(pages: list[dict], slug_to_id: dict[str, str]) -> list[dict]:
         # 2. Mentions edges from body wikilinks.
         seen_targets: set[str] = set()
         for link in p["links"]:
-            target_slug = link.split("#")[0].strip()
+            target_slug = resolve_link_slug(link, path_to_slug, known_slugs)
             if not target_slug or target_slug == slug:
                 continue
             target_id = slug_to_id.get(target_slug)

--- a/skills/llm-wiki/scripts/wiki_lint.py
+++ b/skills/llm-wiki/scripts/wiki_lint.py
@@ -39,6 +39,46 @@ FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 CAPITALIZED_PHRASE_RE = re.compile(r"\b([A-Z][a-zA-Z0-9]+(?:\s+[A-Z][a-zA-Z0-9]+){0,3})\b")
 
 
+def clean_link_target(link: str) -> str:
+    """Strip a wikilink down to its path, dropping alias, anchor, and .md."""
+    target = link.split("|", 1)[0]      # drop a display alias, if any
+    target = target.split("#", 1)[0]    # drop a heading anchor
+    target = target.replace("\\", "/").strip().strip("/")
+    if target.lower().endswith(".md"):
+        target = target[:-3]
+    return target.strip()
+
+
+def resolve_link(link: str, by_path: dict, by_slug) -> "str | None":
+    """Resolve a wikilink to the slug of the page it names, or None if broken.
+
+    Wikilinks appear both bare ([[kalman-filter]]) and path-qualified
+    ([[entities/kalman-filter]]), optionally with a heading anchor or an
+    explicit .md. A page's identity is its filename stem, so comparing raw
+    link text misses every path-qualified form — reporting it broken and
+    contributing no inbound edge, which then also misreports well-referenced
+    pages as orphans.
+
+    A directory prefix is treated as a CONSTRAINT, not decoration: a qualified
+    link resolves only if that exact path exists. Falling back to a bare-stem
+    match would let [[raw/foo]] silently bind to sources/foo.md — a live
+    collision pattern wherever source pages are named after their raw files —
+    turning a genuinely broken out-of-tree link into a false pass. Unresolvable
+    is the safe answer; a wrong resolution is not.
+
+    Matching is case-SENSITIVE in both forms. Case-folding paths (but not bare
+    slugs) would be an asymmetry, and of the two ways to be wrong, a spurious
+    "broken link" report is visible and harmless while a spurious resolution is
+    silent.
+    """
+    target = clean_link_target(link)
+    if not target:
+        return None
+    if "/" in target:
+        return by_path.get(target)
+    return target if target in by_slug else None
+
+
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "index.md", "log.md", "README.md"}
 SKIP_TOP_LEVEL_DIRS = {"indexes", "graph", "raw"}
 
@@ -149,9 +189,21 @@ def lint(pages: list[dict], soft_cap: int, hard_cap: int, required_fm: list[str]
     # Inbound link map
     inbound = defaultdict(set)
     all_slugs = set(slug_to_pages.keys())
+    # Resolution indexes: by full wiki-relative path (sans .md) for
+    # path-qualified links, and by bare stem for unqualified ones.
+    by_slug = all_slugs
+    by_path = {}
+    for p in pages:
+        rel = p["rel_path"].replace("\\", "/")
+        if rel.lower().endswith(".md"):
+            rel = rel[:-3]
+        by_path[rel] = p["slug"]
+
     for p in pages:
         for link in p["links"]:
-            inbound[link].add(p["slug"])
+            resolved = resolve_link(link, by_path, by_slug)
+            if resolved:
+                inbound[resolved].add(p["slug"])
 
     # Orphans, broken links, oversize, frontmatter, staleness
     for p in pages:
@@ -161,7 +213,7 @@ def lint(pages: list[dict], soft_cap: int, hard_cap: int, required_fm: list[str]
 
         # Broken links
         for link in p["links"]:
-            if link not in all_slugs:
+            if resolve_link(link, by_path, by_slug) is None:
                 findings["broken_links"].append({
                     "from": p["slug"],
                     "from_path": p["rel_path"],

--- a/skills/llm-wiki/scripts/wiki_search.py
+++ b/skills/llm-wiki/scripts/wiki_search.py
@@ -165,6 +165,45 @@ def write_parse_cache(cache_path: Path, files: dict) -> None:
     os.replace(temporary, cache_path)
 
 
+def clean_link_target(link: str) -> str:
+    """Strip a wikilink down to its path, dropping alias, anchor, and .md."""
+    target = link.split("|", 1)[0]      # drop a display alias, if any
+    target = target.split("#", 1)[0]    # drop a heading anchor
+    target = target.replace("\\", "/").strip().strip("/")
+    if target.lower().endswith(".md"):
+        target = target[:-3]
+    return target.strip()
+
+
+def build_link_index(pages: list[dict]) -> tuple[dict, set]:
+    """Return (path -> slug, {slug}) for resolving wikilinks."""
+    by_path = {}
+    for p in pages:
+        rel = p["rel_path"].replace("\\", "/")
+        if rel.lower().endswith(".md"):
+            rel = rel[:-3]
+        by_path[rel] = p["slug"]
+    return by_path, {p["slug"] for p in pages}
+
+
+def resolve_link(link: str, by_path: dict, by_slug) -> "str | None":
+    """Resolve a wikilink to the page slug it names, or None.
+
+    Bare ([[kalman-filter]]) and path-qualified ([[entities/kalman-filter]])
+    forms both name a page whose identity is its filename stem, so comparing
+    raw link text makes --backlinks miss every path-qualified reference and
+    splits --top-linked counts across the two forms. A directory prefix is a
+    CONSTRAINT, not decoration: a qualified link resolves only if that exact
+    path exists, so [[raw/foo]] cannot masquerade as sources/foo.
+    """
+    target = clean_link_target(link)
+    if not target:
+        return None
+    if "/" in target:
+        return by_path.get(target)
+    return target if target in by_slug else None
+
+
 def collect_pages(wiki_root: Path, cache_path: Path | None = None) -> list[dict]:
     """Walk the wiki and return [{path, slug, meta, body, tokens, links}]."""
     pages = []
@@ -761,10 +800,13 @@ def cmd_search(args, pages: list[dict]) -> None:
 
 
 def cmd_backlinks(args, pages: list[dict]) -> None:
-    target = args.backlinks
+    by_path, by_slug = build_link_index(pages)
+    target = resolve_link(args.backlinks, by_path, by_slug) \
+        or clean_link_target(args.backlinks)
     inbound = []
     for page in pages:
-        if target in page["links"]:
+        if any(resolve_link(link, by_path, by_slug) == target
+               for link in page["links"]):
             inbound.append(page)
     if not inbound:
         print(f"No pages link to [[{target}]].", file=sys.stderr)
@@ -776,10 +818,13 @@ def cmd_backlinks(args, pages: list[dict]) -> None:
 
 
 def cmd_top_linked(args, pages: list[dict]) -> None:
+    by_path, by_slug = build_link_index(pages)
     inbound_count = Counter()
     for page in pages:
         for link in page["links"]:
-            inbound_count[link] += 1
+            resolved = resolve_link(link, by_path, by_slug)
+            if resolved:
+                inbound_count[resolved] += 1
     top = inbound_count.most_common(args.top_linked)
     if not top:
         print("No links found in the wiki.", file=sys.stderr)

--- a/skills/llm-wiki/scripts/wiki_stats.py
+++ b/skills/llm-wiki/scripts/wiki_stats.py
@@ -22,6 +22,29 @@ WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
 
+def link_stem(link: str) -> str:
+    """Reduce a wikilink to the page stem it names, for popularity counting.
+
+    Bare ([[kalman-filter]]), path-qualified ([[entities/kalman-filter]]),
+    anchored, and .md-suffixed forms all name the same page. Counting raw link
+    text splits one page's inbound total across those forms and understates
+    hubs.
+
+    NOTE: unlike wiki_lint / wiki_search, this does NOT verify that the target
+    resolves — a link to an out-of-tree path such as [[raw/foo]] is counted
+    under the stem "foo". That is acceptable here because these are popularity
+    counts, not a correctness gate; do not reuse this function to decide
+    whether a link is broken.
+    """
+    target = link.split("|", 1)[0]      # drop a display alias, if any
+    target = target.split("#", 1)[0]    # drop a heading anchor
+    target = target.replace("\\", "/").strip().strip("/")
+    target = target.rsplit("/", 1)[-1]  # drop any directory prefix
+    if target.lower().endswith(".md"):
+        target = target[:-3]
+    return target.strip()
+
+
 SKIP_TOP_LEVEL_FILES = {"SCHEMA.md", "log.md", "README.md"}
 SKIP_TOP_LEVEL_DIRS = {"indexes", "graph", "raw"}
 
@@ -84,8 +107,7 @@ def main():
         links = WIKILINK_RE.findall(body)
         total_links += len(links)
         for link in links:
-            target = link.split("|")[0].strip()
-            most_linked_in[target] += 1
+            most_linked_in[link_stem(link)] += 1
         page_type = parse_type(text) or "(none)"
         pages_by_type[page_type] += 1
         if len(rel.parts) > 1:


### PR DESCRIPTION
## The bug

All four bundled scripts compare raw wikilink text against page slugs, where a slug is the bare filename stem (`md_path.stem`). A link written as `[[entities/kalman-filter]]` therefore matches nothing, because no slug is ever `entities/kalman-filter`.

Since path-qualified links are a common authoring form (and what Obsidian produces when two pages share a name), this misfires constantly — and it misfires silently, differently in each script:

| Script | Symptom |
|---|---|
| `wiki_lint.py` | Reports every path-qualified link as a broken link. Inbound edges are keyed the same way, so well-referenced pages *also* report as orphans. |
| `wiki_graph_extract.py` | Emits no `mentions` edge for them at all — the graph is quietly missing edges, with no error anywhere. |
| `wiki_search.py` | `--backlinks` misses every path-qualified reference; `--top-linked` splits one page's count across the bare and qualified forms. |
| `wiki_stats.py` | Understates hubs the same way. |

Measured on one 55-page wiki before/after:

- broken links **153 → 11** (142 were false)
- orphan pages **16 → 1** (15 were false)
- `mentions` edges **182 → 308** (126 were missing from the graph)

The remaining 11 and 1 are genuine.

## The fix

Each script normalizes a link before comparing — display alias, heading anchor, and `.md` suffix are stripped.

**A directory prefix is treated as a constraint, not decoration.** A qualified link resolves only if that exact path exists, and there is deliberately *no* fall back to a bare-stem match. Falling back looks harmless but would let `[[raw/foo]]` resolve to `sources/foo.md` — and that collision is not hypothetical, since source pages are conventionally named after the raw file they summarize. It would convert a genuinely broken out-of-tree link into a false pass, which is strictly worse than the bug being fixed here: unresolvable is a safe answer, a wrong resolution is not.

Matching is case-sensitive in both forms, so paths and bare slugs behave alike rather than one being laxer than the other.

`wiki_stats.py` is a deliberate exception: it counts popularity rather than adjudicating correctness, so it reduces to the stem and does not verify resolution. That difference is documented at the function and pinned by a test, so it isn't later "fixed" into a correctness check by accident.

`wiki_graph_lint.py` collects `links` but never consumes them, so it needed no change.

## Tests

Adds `skills/llm-wiki/scripts/test_link_resolution.py` — stdlib only, no test framework, run it directly:

```
python3 skills/llm-wiki/scripts/test_link_resolution.py
```

43 cases across all four resolvers, including guard cases that fail if the path constraint is ever relaxed (`[[raw/<stem>]]` and `[[personas/<stem>]]` must not bind to a same-stem page elsewhere in the tree).

## Checklist

- [x] All four bundled scripts run without error against a small test wiki (`init_wiki.py` into a temp dir, plus hand-written pages containing a bare link, a path-qualified link, and a deliberately broken one — only the broken one is reported).
- [x] `plugin.json` / `marketplace.json` both parse.
- [x] `CHANGELOG.md` entry added under `[Unreleased] → Fixed`.
- [x] No `SKILL.md` description change.
- [x] Pure stdlib, no new dependencies.
- [ ] Not verified: plugin loading in Claude Code via `/plugin marketplace add`. This change touches only the Python scripts — no manifest, skill, or command files — so I would not expect it to affect loading, but I haven't run that check and would rather say so than tick it.

No version bump, since `CONTRIBUTING.md` reserves that for the maintainer release checklist. Happy to adjust anything here.
